### PR TITLE
Make all events go through the DOM

### DIFF
--- a/cypress/e2e/instance.cy.js
+++ b/cypress/e2e/instance.cy.js
@@ -44,21 +44,21 @@ describe('Instance', () => {
     cy.window()
       .its('instance')
 
-      .invoke('on', 'show', container => {
-        expect(container.id).to.eq('my-dialog')
+      .invoke('on', 'show', event => {
+        expect(event.target.id).to.eq('my-dialog')
         logs.push('Shown')
       })
 
-      .invoke('on', 'hide', container => {
-        expect(container.id).to.eq('my-dialog')
+      .invoke('on', 'hide', event => {
+        expect(event.target.id).to.eq('my-dialog')
         logs.push('Hidden')
       })
 
       .invoke('on', 'hide', event)
       .invoke('off', 'hide', event)
 
-      .invoke('on', 'destroy', container => {
-        expect(container.id).to.eq('my-dialog')
+      .invoke('on', 'destroy', event => {
+        expect(event.target.id).to.eq('my-dialog')
         logs.push('Destroyed')
       })
 

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -2,7 +2,6 @@ import focusableSelectors from 'focusable-selectors'
 
 export type A11yDialogEvent = 'show' | 'hide' | 'destroy'
 export type A11yDialogInstance = InstanceType<typeof A11yDialog>
-export type A11yDialogEventHandler = (node: Element, event?: Event) => void
 
 export default class A11yDialog {
   private $el: HTMLElement
@@ -124,7 +123,7 @@ export default class A11yDialog {
    */
   public on = (
     type: A11yDialogEvent,
-    handler: A11yDialogEventHandler
+    handler: EventListener
   ): A11yDialogInstance => {
     this.$el.addEventListener(type, handler)
 
@@ -136,7 +135,7 @@ export default class A11yDialog {
    */
   public off = (
     type: A11yDialogEvent,
-    handler: A11yDialogEventHandler
+    handler: EventListener
   ): A11yDialogInstance => {
     this.$el.removeEventListener(type, handler)
 

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -123,9 +123,10 @@ export default class A11yDialog {
    */
   public on = (
     type: A11yDialogEvent,
-    handler: EventListener
+    handler: EventListener,
+    options?: AddEventListenerOptions
   ): A11yDialogInstance => {
-    this.$el.addEventListener(type, handler)
+    this.$el.addEventListener(type, handler, options)
 
     return this
   }
@@ -135,9 +136,10 @@ export default class A11yDialog {
    */
   public off = (
     type: A11yDialogEvent,
-    handler: EventListener
+    handler: EventListener,
+    options?: AddEventListenerOptions
   ): A11yDialogInstance => {
-    this.$el.removeEventListener(type, handler)
+    this.$el.removeEventListener(type, handler, options)
 
     return this
   }

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -4,16 +4,11 @@ export type A11yDialogEvent = 'show' | 'hide' | 'destroy'
 export type A11yDialogInstance = InstanceType<typeof A11yDialog>
 export type A11yDialogEventHandler = (node: Element, event?: Event) => void
 
-type ListenersRecord = Partial<
-  Record<A11yDialogEvent, A11yDialogEventHandler[]>
->
-
 export default class A11yDialog {
   private $el: HTMLElement
   private id: string
   private openers: HTMLElement[]
   private closers: HTMLElement[]
-  private listeners: ListenersRecord = {}
   private previouslyFocused: HTMLElement | null = null
 
   public shown = false
@@ -67,9 +62,6 @@ export default class A11yDialog {
 
     // Execute all callbacks registered for the `destroy` event
     this.fire('destroy')
-
-    // Empty the listeners map
-    this.listeners = {}
 
     return this
   }
@@ -134,10 +126,7 @@ export default class A11yDialog {
     type: A11yDialogEvent,
     handler: A11yDialogEventHandler
   ): A11yDialogInstance => {
-    const listeners = this.listeners[type] || []
-    listeners.push(handler)
-
-    this.listeners[type] = listeners
+    this.$el.addEventListener(type, handler)
 
     return this
   }
@@ -149,10 +138,7 @@ export default class A11yDialog {
     type: A11yDialogEvent,
     handler: A11yDialogEventHandler
   ): A11yDialogInstance => {
-    const listeners = this.listeners[type] || []
-    const index = listeners.indexOf(handler)
-
-    if (index > -1) listeners.splice(index, 1)
+    this.$el.removeEventListener(type, handler)
 
     return this
   }
@@ -164,11 +150,7 @@ export default class A11yDialog {
    * possible to react to the lifecycle of auto-instantiated dialogs.
    */
   private fire = (type: A11yDialogEvent, event?: Event) => {
-    const listeners = this.listeners[type] || []
-    const domEvent = new CustomEvent(type, { detail: event })
-
-    this.$el.dispatchEvent(domEvent)
-    listeners.forEach(listener => listener(this.$el, event))
+    this.$el.dispatchEvent(new CustomEvent(type, { detail: event }))
   }
 
   /**


### PR DESCRIPTION
This is a proof of concept that would make all events go through the DOM under the hood. This would mean they would no longer be attached to the dialog instance itself, but on the dialog DOM container instead. This just reduces the amount of code shipped (not by a lot though).

~The way this is implemented would likely cause no API breaking change.~ The object passed to the events would now be a `CustomEvent`, and accessing the underlying DOM node would require reading `event.detail.currentTarget` instead of `event.currentTarget`, so this is a breaking change.

We could also decide to drop `.on` and `.off` methods entirely, but it might be good to keep them for convenience. Otherwise the API would be a little awkward (having to read the element from the instance to bind listeners).