### PR TITLE
Adds svelte-a11y-dialog to implementations page

### DIFF
--- a/docs/further_reading.implementations.md
+++ b/docs/further_reading.implementations.md
@@ -7,3 +7,4 @@ If you happen to work with [React](https://github.com/facebook/react/) or [Vue](
 
 - [react-a11y-dialog](https://github.com/KittyGiraudel/react-a11y-dialog)
 - [vue-a11y-dialog](https://github.com/morkro/vue-a11y-dialog)
+- [svelte-a11y-dialog](https://github.com/AgnosticUI/svelte-a11y-dialog)

--- a/versioned_docs/version-7.0.0/further_reading.implementations.md
+++ b/versioned_docs/version-7.0.0/further_reading.implementations.md
@@ -7,3 +7,4 @@ If you happen to work with [React](https://github.com/facebook/react/) or [Vue](
 
 - [react-a11y-dialog](https://github.com/KittyGiraudel/react-a11y-dialog)
 - [vue-a11y-dialog](https://github.com/morkro/vue-a11y-dialog)
+- [svelte-a11y-dialog](https://github.com/AgnosticUI/svelte-a11y-dialog)


### PR DESCRIPTION
This adds Adds svelte-a11y-dialog link

In local this shows up in 7.x and "next" implementation pages, but not 6.x implementation page