### PR TITLE
Merge `create` method into constructor

### DIFF
--- a/src/a11y-dialog.d.ts
+++ b/src/a11y-dialog.d.ts
@@ -1,12 +1,9 @@
 declare namespace A11yDialog {
-  export type Targets = NodeList | Element | string;
   export type EventHandler = (node: Element, event?: Event) => void;
   export type EventType = "show" | "hide" | "destroy" | "create";
 
   export class A11yDialog {
     constructor(node: Element, targets?: Targets);
-
-    create(targets: Targets): A11yDialog;
 
     show(event?: Event): A11yDialog;
 

--- a/src/a11y-dialog.js
+++ b/src/a11y-dialog.js
@@ -25,15 +25,6 @@ function A11yDialog(element) {
   this._listeners = {}
 
   // Initialise everything needed for the dialog to work properly
-  this.create()
-}
-
-/**
- * Set up everything necessary for the dialog to be functioning
- *
- * @return {A11yDialog}
- */
-A11yDialog.prototype.create = function () {
   this.$el.setAttribute('aria-hidden', true)
   this.$el.setAttribute('aria-modal', true)
   this.$el.setAttribute('tabindex', -1)
@@ -64,8 +55,6 @@ A11yDialog.prototype.create = function () {
 
   // Execute all callbacks registered for the `create` event
   this._fire('create')
-
-  return this
 }
 
 /**


### PR DESCRIPTION
## Summary
As it says on the tin. Also gets rid of a `Targets` type that is only referenced for `create` and wasn't being used by `create` anyway.

Step two of work discussed in #373