### PR TITLE
Remove babel from Rollup config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
       },
       "devDependencies": {
         "@babel/preset-env": "^7.18.6",
-        "@rollup/plugin-babel": "^5.3.1",
         "@rollup/plugin-node-resolve": "^13.3.0",
         "@rollup/plugin-typescript": "^8.3.3",
         "cypress": "^10.3.0",
@@ -1747,29 +1746,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@rollup/plugin-babel": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
-      "integrity": "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.10.4",
-        "@rollup/pluginutils": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0",
-        "@types/babel__core": "^7.1.9",
-        "rollup": "^1.20.0||^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/babel__core": {
-          "optional": true
-        }
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -6376,16 +6352,6 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "@rollup/plugin-babel": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
-      "integrity": "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.10.4",
-        "@rollup/pluginutils": "^3.1.0"
       }
     },
     "@rollup/plugin-node-resolve": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.18.6",
-    "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@rollup/plugin-typescript": "^8.3.3",
     "cypress": "^10.3.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,30 +1,9 @@
 import { terser } from 'rollup-plugin-terser'
 import pkg from './package.json'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
-import { babel } from '@rollup/plugin-babel'
 import typescript from '@rollup/plugin-typescript'
 
-const babelCfg = {
-  babelHelpers: 'bundled',
-  assumptions: {
-    enumerableModuleMeta: true,
-    mutableTemplateObject: true,
-    noClassCalls: true,
-    noDocumentAll: true,
-  },
-  extensions: ['.ts'],
-  include: ['src/**/*'],
-  presets: [['@babel/preset-env', { targets: 'ie 11' }]],
-}
-
-const commonPlugins = [
-  nodeResolve(),
-  typescript({ tsconfig: './tsconfig.json' }),
-]
-
-const esmPlugins = commonPlugins
-
-const umdPlugins = [...commonPlugins, babel(babelCfg)]
+const plugins = [nodeResolve(), typescript({ tsconfig: './tsconfig.json' })]
 
 const minify = terser({
   format: {
@@ -41,7 +20,7 @@ const umdCfg = {
 export default [
   {
     input: 'src/a11y-dialog.ts',
-    plugins: umdPlugins,
+    plugins: plugins,
     output: [
       {
         ...umdCfg,
@@ -60,7 +39,7 @@ export default [
   },
   {
     input: 'src/a11y-dialog.ts',
-    plugins: esmPlugins,
+    plugins: plugins,
     output: [
       {
         file: 'dist/a11y-dialog.esm.js',


### PR DESCRIPTION
## Summary
**With this PR, we are dropping support for IE 11 in the upcoming version 8.** Code is no longer downleveled in any way at bundle time.