### PR TITLE
chore: replace `cypress-plugin-tab` with `cypress-real-events`

### DIFF
--- a/cypress/e2e/focus.cy.js
+++ b/cypress/e2e/focus.cy.js
@@ -7,17 +7,14 @@ describe('Focus', () => {
   })
 
   it('should trap the focus within the dialog', () => {
-    // The next line is a hack, because the `cypress-plugin-tab` library does
-    // not consider elements with `tabindex="-1"` to be valid subject for the
-    // `.tab()` command, which means we can’t tab from the dialog into it.
-    cy.get('.dialog-close').focus()
-    cy.get('.dialog-close').tab()
-    cy.get('input[type="email"]')
-      .should('have.focus')
-      .tab({ shift: true })
-      .tab({ shift: true })
-    cy.get('#move-focus-outside').should('have.focus').tab()
-    cy.get('.dialog-close').should('have.focus')
+    // Press Tab and verify that the correct element is focused
+    cy.realPress('Tab').focused().should('have.class', 'dialog-close')
+
+    // Tab backwards and verify that we've looped around
+    // to the last focusable element
+    cy.realPress(['Shift', 'Tab'])
+      .focused()
+      .should('have.id', 'move-focus-outside')
   })
 
   it('should maintain focus in the dialog', () => {

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,1 +1,1 @@
-require('cypress-plugin-tab')
+import 'cypress-real-events/support'

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@rollup/plugin-node-resolve": "^13.3.0",
         "@rollup/plugin-typescript": "^8.3.3",
         "cypress": "^10.3.0",
-        "cypress-plugin-tab": "^1.0.5",
+        "cypress-real-events": "^1.7.1",
         "husky": "^8.0.1",
         "lint-staged": "^13.0.3",
         "prettier": "^2.7.1",
@@ -1882,16 +1882,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ally.js": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/ally.js/-/ally.js-1.4.1.tgz",
-      "integrity": "sha512-ZewdfuwP6VewtMN36QY0gmiyvBfMnmEaNwbVu2nTS6zRt069viTgkYgaDiqu6vRJ1VJCriNqV0jGMu44R8zNbA==",
-      "dev": true,
-      "dependencies": {
-        "css.escape": "^1.5.0",
-        "platform": "1.3.3"
-      }
-    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -2501,12 +2491,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css.escape": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true
-    },
     "node_modules/cypress": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.3.1.tgz",
@@ -2564,13 +2548,13 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/cypress-plugin-tab": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/cypress-plugin-tab/-/cypress-plugin-tab-1.0.5.tgz",
-      "integrity": "sha512-QtTJcifOVwwbeMP3hsOzQOKf3EqKsLyjtg9ZAGlYDntrCRXrsQhe4ZQGIthRMRLKpnP6/tTk6G0gJ2sZUfRliQ==",
+    "node_modules/cypress-real-events": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.7.1.tgz",
+      "integrity": "sha512-/Bg15RgJ0SYsuXc6lPqH08x19z6j2vmhWN4wXfJqm3z8BTAFiK2MvipZPzxT8Z0jJP0q7kuniWrLIvz/i/8lCQ==",
       "dev": true,
-      "dependencies": {
-        "ally.js": "^1.4.1"
+      "peerDependencies": {
+        "cypress": "^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x"
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
@@ -4329,12 +4313,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/platform": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.3.tgz",
-      "integrity": "sha512-VJK1SRmXBpjwsB4YOHYSturx48rLKMzHgCqDH2ZDa6ZbMS/N5huoNqyQdK5Fj/xayu3fqbXckn5SeCS1EbMDZg==",
-      "dev": true
     },
     "node_modules/prettier": {
       "version": "2.7.1",
@@ -6456,16 +6434,6 @@
         "indent-string": "^4.0.0"
       }
     },
-    "ally.js": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/ally.js/-/ally.js-1.4.1.tgz",
-      "integrity": "sha512-ZewdfuwP6VewtMN36QY0gmiyvBfMnmEaNwbVu2nTS6zRt069viTgkYgaDiqu6vRJ1VJCriNqV0jGMu44R8zNbA==",
-      "dev": true,
-      "requires": {
-        "css.escape": "^1.5.0",
-        "platform": "1.3.3"
-      }
-    },
     "ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -6897,12 +6865,6 @@
         "which": "^2.0.1"
       }
     },
-    "css.escape": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true
-    },
     "cypress": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.3.1.tgz",
@@ -7030,14 +6992,12 @@
         }
       }
     },
-    "cypress-plugin-tab": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/cypress-plugin-tab/-/cypress-plugin-tab-1.0.5.tgz",
-      "integrity": "sha512-QtTJcifOVwwbeMP3hsOzQOKf3EqKsLyjtg9ZAGlYDntrCRXrsQhe4ZQGIthRMRLKpnP6/tTk6G0gJ2sZUfRliQ==",
+    "cypress-real-events": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.7.1.tgz",
+      "integrity": "sha512-/Bg15RgJ0SYsuXc6lPqH08x19z6j2vmhWN4wXfJqm3z8BTAFiK2MvipZPzxT8Z0jJP0q7kuniWrLIvz/i/8lCQ==",
       "dev": true,
-      "requires": {
-        "ally.js": "^1.4.1"
-      }
+      "requires": {}
     },
     "dashdash": {
       "version": "1.14.1",
@@ -8222,12 +8182,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true
-    },
-    "platform": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.3.tgz",
-      "integrity": "sha512-VJK1SRmXBpjwsB4YOHYSturx48rLKMzHgCqDH2ZDa6ZbMS/N5huoNqyQdK5Fj/xayu3fqbXckn5SeCS1EbMDZg==",
       "dev": true
     },
     "prettier": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@rollup/plugin-typescript": "^8.3.3",
     "cypress": "^10.3.0",
-    "cypress-plugin-tab": "^1.0.5",
+    "cypress-real-events": "^1.7.1",
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
     "prettier": "^2.7.1",


### PR DESCRIPTION
## Summary

`cypress-plugin-tab` does not play nicely with Shadow DOM subtrees. Using `cypress-real-events` will allow us to test DOM structures with shadow subtrees, which will help us to close #322.