### PR TITLE
Handle shadow children when trapping focus

### DIFF
--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -244,7 +244,7 @@ function getFocusableChildren(node: ParentNode): HTMLElement[] {
   if (node instanceof HTMLElement) {
     // If this node is marked as inert, neither it nor any member of
     // its subtree will be focusable.
-    if (node.inert === true) return []
+    if (node.inert) return []
 
     // If this node has no children, we can stop traversing.
     // If this node has children, but nullifies its children's
@@ -265,13 +265,13 @@ function getFocusableChildren(node: ParentNode): HTMLElement[] {
   for (const curr of node.children as unknown as HTMLElement[]) {
     // If this element has a Shadow DOM attached,
     // check the shadow subtree for focusable children.
-    if (!!curr.shadowRoot) {
+    if (curr.shadowRoot) {
       focusableEls = [...focusableEls, ...getFocusableChildren(curr.shadowRoot)]
 
       // If this is a slot, look for any elements assigned to it
       // then check each of those for focusable children.
     } else if (curr.localName === 'slot') {
-      let assignedElements = (curr as HTMLSlotElement).assignedElements()
+      const assignedElements = (curr as HTMLSlotElement).assignedElements()
       for (const assignedElement of assignedElements) {
         focusableEls = [
           ...focusableEls,

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -234,18 +234,22 @@ const PRESENTATIONAL_CHILDREN_SELECTOR = `
  * This traversal allows us to account for Shadow DOM subtrees.
  */
 function getFocusableChildren(node: ParentNode): HTMLElement[] {
-  // Check for the base case of our recursion:
-  // If this node has no element children, or
-  // it *does* have element children, but it nullifies
-  // the semantics of those children, we can stop traversing.
-  if (
-    !node.firstElementChild ||
-    (node as HTMLElement).matches(PRESENTATIONAL_CHILDREN_SELECTOR)
-  ) {
-    // Check if the node is focusable, and then return early.
-    return isFocusable(node as HTMLAnchorElement)
-      ? [node as HTMLAnchorElement]
-      : []
+  // Check for the bases case of our recursion:
+  if (node instanceof HTMLElement) {
+    // If this node is marked as inert, neither it nor any member of
+    // its subtree will be focusable.
+    if (node.inert === true) return []
+
+    // If this node has no children, we can stop traversing.
+    // If this node has children, but nullifies its children's
+    // semantics, we can stop traversing.
+    if (
+      !node.firstElementChild ||
+      node.matches(PRESENTATIONAL_CHILDREN_SELECTOR)
+    ) {
+      // Check if the node is focusable, and then return early.
+      return isFocusable(node) ? [node] : []
+    }
   }
 
   let focusableEls: HTMLElement[] = []
@@ -324,5 +328,13 @@ if (typeof document !== 'undefined') {
     document.addEventListener('DOMContentLoaded', instantiateDialogs)
   } else {
     instantiateDialogs()
+  }
+}
+
+// TypeScript doesn't know about `inert` yet; this declaration extends
+// the HTMLElement interface to include it.
+declare global {
+  interface HTMLElement {
+    inert: boolean
   }
 }

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -277,6 +277,9 @@ function getFocusableChildren(node: ParentNode): HTMLElement[] {
   return focusableEls
 }
 
+/**
+ * Determine if an element is focusable and has user-visible painted dimensions
+ */
 function isFocusable(el: HTMLElement) {
   return (
     el.matches(focusableSelectors.join(',')) &&

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -212,8 +212,9 @@ function moveFocusToDialog(node: HTMLElement) {
   focused.focus()
 }
 
-// Elements with these ARIA roles implicitly nullify
-// the semantics of their children.
+// Elements with these ARIA roles make their children
+// `presentational`, which nullifies their semantics.
+// @see: https://www.w3.org/TR/wai-aria/
 const PRESENTATIONAL_CHILDREN_SELECTOR = `
   a[href],
   button,

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -221,19 +221,20 @@ function moveFocusToDialog(node: HTMLElement) {
 // Elements with these ARIA roles make their children
 // `presentational`, which nullifies their semantics.
 // @see: https://www.w3.org/TR/wai-aria/
-const PRESENTATIONAL_CHILDREN_SELECTOR = `
-  a[href],
-  button,
-  img,
-  summary,
-  [role="button"],
-  [role="image"],
-  [role="link"],
-  [role="math"],
-  [role="progressbar"],
-  [role="scrollbar"],
-  [role="slider"]
-`
+const PRESENTATIONAL_CHILDREN_SELECTOR = [
+  'a[href]',
+  'button',
+  'img',
+  'summary',
+  '[role="button"]',
+  '[role="image"]',
+  '[role="link"]',
+  '[role="math"]',
+  '[role="presentation"]',
+  '[role="progressbar"]',
+  '[role="scrollbar"]',
+  '[role="slider"]',
+].join(',')
 
 /**
  * Get focusable children by recursively traversing the subtree of `node`.


### PR DESCRIPTION
## Summary
This overhaul of `getFocusableChildren` replaces `querySelectorAll` with a manual, recursive DOM traversal. This traversal is necessary because there's no way to query into shadow subtrees.

I have ideas for tests, as well, but I will follow up with them in a separate PR to keep this one small.

Huge thanks to the inimitable @alice for listening to me complain about Shadow DOM and helping me figure this algorithm out.

## Relevant issues
Closes #322.