### PR TITLE
Fix incorrect handling of nested dialogs

### DIFF
--- a/a11y-dialog.js
+++ b/a11y-dialog.js
@@ -53,9 +53,22 @@ A11yDialog.prototype.create = function () {
 
   // Keep a collection of dialog closers, each of which will be bound a click
   // event listener to close the dialog
-  this._closers = $$('[data-a11y-dialog-hide]', this.$el).concat(
-    $$('[data-a11y-dialog-hide="' + this._id + '"]')
-  )
+  const $el = this.$el
+
+  this._closers = $$('[data-a11y-dialog-hide]', this.$el)
+    // This filter is necessary in case there are nested dialogs, so that
+    // only closers from the current dialog are retrieved and effective
+    .filter(function (closer) {
+      // Testing for `[aria-modal="true"]` is not enough since this attribute
+      // and the collect of closers is done at instantation time, when nested
+      // dialogs might not have yet been instantiated. Note that if the dialogs
+      // are manually instantiated, this could still fail because none of these
+      // selectors would match; this would cause closers to close all parent
+      // dialogs instead of just the current one
+      return closer.closest('[aria-modal="true"], [data-a11y-dialog]') === $el
+    })
+    .concat($$('[data-a11y-dialog-hide="' + this._id + '"]'))
+
   this._closers.forEach(
     function (closer) {
       closer.addEventListener('click', this._hide)
@@ -236,7 +249,8 @@ A11yDialog.prototype._fire = function (type, event) {
 A11yDialog.prototype._bindKeypress = function (event) {
   // This is an escape hatch in case there are nested dialogs, so the keypresses
   // are only reacted to for the most recent one
-  if (!this.$el.contains(document.activeElement)) return
+  const focused = document.activeElement
+  if (focused && focused.closest('[aria-modal="true"]') !== this.$el) return
 
   // If the dialog is shown and the ESCAPE key is being pressed, prevent any
   // further effects from the ESCAPE key and hide the dialog, unless its role

--- a/cypress/e2e/nestedDialogs.cy.js
+++ b/cypress/e2e/nestedDialogs.cy.js
@@ -13,15 +13,15 @@ describe('Nested dialogs', () => {
   })
 
   it('should close only the top most dialog when pressing ESC', () => {
-    cy.get('body').trigger('keydown', { keyCode: 27, which: 27 })
+    cy.get('html').trigger('keydown', { key: 'Escape', keyCode: 27, which: 27 })
     cy.get('[data-a11y-dialog="dialog-2"]').then(shouldBeVisible)
     cy.get('[data-a11y-dialog="dialog-3"]').then(shouldBeHidden)
   })
 
   it('should close only the top most dialog when clicking the backdrop', () => {
-    cy.get('body').trigger('keydown', { keyCode: 27, which: 27 })
     cy.get('[data-a11y-dialog="dialog-2"]')
       .find('.dialog-overlay')
+      .first()
       .click({ force: true })
     cy.get('[data-a11y-dialog="dialog-1"]').then(shouldBeVisible)
     cy.get('[data-a11y-dialog="dialog-2"]').then(shouldBeHidden)

--- a/cypress/fixtures/nested-dialogs.html
+++ b/cypress/fixtures/nested-dialogs.html
@@ -21,27 +21,26 @@
       <h1 id="dialog-title-1">Dialog 1</h1>
       <button class="link-like" data-a11y-dialog-show="dialog-2">Open dialog 2</button>
     </div>
-  </div>
 
-  <div class="dialog" data-a11y-dialog="dialog-2" aria-hidden="true" aria-labelledby="dialog-title-2">
-    <div class="dialog-overlay" data-a11y-dialog-hide></div>
-    <div role="document" class="dialog-content">
-      <button data-a11y-dialog-hide class="dialog-close" aria-label="Close this dialog window">&times;</button>
+    <div class="dialog" data-a11y-dialog="dialog-2" aria-hidden="true" aria-labelledby="dialog-title-2">
+      <div class="dialog-overlay" data-a11y-dialog-hide></div>
+      <div role="document" class="dialog-content">
+        <button data-a11y-dialog-hide class="dialog-close" aria-label="Close this dialog window">&times;</button>
 
-      <h1 id="dialog-title-2">Dialog 2</h1>
-      <button class="link-like" data-a11y-dialog-show="dialog-3">Open dialog 3</button>
+        <h1 id="dialog-title-2">Dialog 2</h1>
+        <button class="link-like" data-a11y-dialog-show="dialog-3">Open dialog 3</button>
+      </div>
+
+      <div class="dialog" data-a11y-dialog="dialog-3" aria-hidden="true" aria-labelledby="dialog-title-3">
+        <div class="dialog-overlay" data-a11y-dialog-hide></div>
+        <div role="document" class="dialog-content">
+          <button data-a11y-dialog-hide class="dialog-close" aria-label="Close this dialog window">&times;</button>
+
+          <h1 id="dialog-title-3">Dialog 3</h1>
+        </div>
+      </div>
     </div>
   </div>
-
-  <div class="dialog" data-a11y-dialog="dialog-3" aria-hidden="true" aria-labelledby="dialog-title-3">
-    <div class="dialog-overlay" data-a11y-dialog-hide></div>
-    <div role="document" class="dialog-content">
-      <button data-a11y-dialog-hide class="dialog-close" aria-label="Close this dialog window">&times;</button>
-
-      <h1 id="dialog-title-3">Dialog 3</h1>
-    </div>
-  </div>
-
 
   <script src="../a11y-dialog.js"></script>
 </body>

--- a/cypress/fixtures/nested-dialogs.html
+++ b/cypress/fixtures/nested-dialogs.html
@@ -22,6 +22,8 @@
       <button class="link-like" data-a11y-dialog-show="dialog-2">Open dialog 2</button>
     </div>
 
+    <!-- It is important that this dialog (#2) lives *within* the
+         `aria-modal="true"` container of its parent dialog (#1) -->
     <div class="dialog" data-a11y-dialog="dialog-2" aria-hidden="true" aria-labelledby="dialog-title-2">
       <div class="dialog-overlay" data-a11y-dialog-hide></div>
       <div role="document" class="dialog-content">
@@ -31,6 +33,8 @@
         <button class="link-like" data-a11y-dialog-show="dialog-3">Open dialog 3</button>
       </div>
 
+      <!-- It is important that this dialog (#3) lives *within* the
+           `aria-modal="true"` container of its parent dialog (#2) -->
       <div class="dialog" data-a11y-dialog="dialog-3" aria-hidden="true" aria-labelledby="dialog-title-3">
         <div class="dialog-overlay" data-a11y-dialog-hide></div>
         <div role="document" class="dialog-content">

--- a/cypress/fixtures/styles.css
+++ b/cypress/fixtures/styles.css
@@ -33,6 +33,7 @@ dialog[open] {
   left: 0;
   bottom: 0;
   right: 0;
+  z-index: 2;
 }
 
 .dialog {


### PR DESCRIPTION
It turns out that the [demo for nested dialogs](https://a11y-dialog.netlify.app/advanced/nested-dialogs) was not working correctly with VoiceOver on Safari. Nothing gets announced passed the first open dialog.

That’s because the dialogs’ DOM tree were laid out flat (as an implementation artifact from the old system from version 6). As a result, “lower“ dialogs ended up *outside* of the `aria-modal="true"` container of the “higher” dialogs. Because of this, VoiceOver on Safari would be unable to pick up their content.

This problem can be solved by properly nesting the nested dialogs’ DOM tree so that “lower” dialogs live within the `aria-modal="true"` container of their “higher” dialog. This way, an open dialog is never outside of an element with `aria-modal="true"`. 

```html
<!-- Before -->
<div data-a11y-dialog="dialog-1" aria-labelledby="dialog-title-1">…</div>
<div data-a11y-dialog="dialog-2" aria-labelledby="dialog-title-2">…</div>
<div data-a11y-dialog="dialog-3" aria-labelledby="dialog-title-3">…</div>

<!-- Now -->
<div data-a11y-dialog="dialog-1" aria-labelledby="dialog-title-1">
  …
  <div data-a11y-dialog="dialog-2" aria-labelledby="dialog-title-2">
    …
    <div data-a11y-dialog="dialog-3" aria-labelledby="dialog-title-3">…</div>
  </div>
</div>
```

Unfortunately, that makes the code to retrieve the elements that can close the dialog a bit more cumbersome since it needs to account for potentially nested dialogs. This code is not quite bulletproof, but it should do the trick in most scenarios, especially when coupled with [better documentation](https://github.com/KittyGiraudel/a11y-dialog/pull/400). It will no longer be an issue [in version 8](https://github.com/KittyGiraudel/a11y-dialog/pull/398) thanks to event delegation.

Kind thanks to @NanneWD for reporting that issue.