### PR TITLE
[Version 8] Fix issue with event delegation

### DIFF
--- a/cypress/e2e/instance.cy.js
+++ b/cypress/e2e/instance.cy.js
@@ -46,10 +46,18 @@ describe('Instance', { testIsolation: false }, () => {
       },
       showManual: event => {
         // When manually showing the dialog, event details should contain the
-        // opener.
-        expect(event.detail.target.getAttribute('data-a11y-dialog-show')).to.eq(
-          'my-dialog'
-        )
+        // element that was interacted with. Important to note that the `target`
+        // is the element that was *interacted with*, which is not always the
+        // element with the `data-a11y-dialog-show` attribute (which could be an
+        // ancestor).
+        const target = event.detail.target
+
+        expect(target.getAttribute('data-testid')).to.eq('inside-span')
+        expect(
+          target
+            .closest('[data-a11y-dialog-show]')
+            .getAttribute('data-a11y-dialog-show')
+        ).to.eq('my-dialog')
         expect(event.target.id).to.eq('my-dialog')
       },
       hide: event => {

--- a/cypress/fixtures/base.html
+++ b/cypress/fixtures/base.html
@@ -10,7 +10,10 @@
 <body>
   <main>
     <h1>Tests — Base</h1>
-    <button class="link-like" data-a11y-dialog-show="my-dialog">Open the dialog window</button>
+    <button class="link-like" data-a11y-dialog-show="my-dialog">
+      <!-- Insert a needless span here to make sure delegated clicks work -->
+      <span>Open the dialog window</span>
+    </button>
     <button class="link-like" data-a11y-dialog-show="something-else">Open the dialog window</button>
   </main>
 

--- a/cypress/fixtures/instance.html
+++ b/cypress/fixtures/instance.html
@@ -10,7 +10,10 @@
 <body>
   <main>
     <h1>Tests — Instance</h1>
-    <button class="link-like" data-a11y-dialog-show="my-dialog">Open the dialog window</button>
+    <button class="link-like" data-a11y-dialog-show="my-dialog">
+      <!-- Insert a needless span here to make sure delegated clicks work -->
+      <span data-testid="inside-span">Open the dialog window</span>
+    </button>
   </main>
 
   <div class="dialog" id="my-dialog" aria-hidden="true" aria-labelledby="my-dialog-title">

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -142,13 +142,15 @@ export default class A11yDialog {
   private handleTriggerClicks = (event: Event) => {
     const target = event.target as HTMLElement
 
-    if (target.matches(`[data-a11y-dialog-show="${this.id}"]`)) {
+    // We use `.closest(..)` and not `.matches(..)` here so that clicking
+    // an element nested within a dialog opener does cause the dialog to open
+    if (target.closest(`[data-a11y-dialog-show="${this.id}"]`)) {
       this.show(event)
     }
 
     if (
-      target.matches(`[data-a11y-dialog-hide="${this.id}"]`) ||
-      (target.matches('[data-a11y-dialog-hide]') &&
+      target.closest(`[data-a11y-dialog-hide="${this.id}"]`) ||
+      (target.closest('[data-a11y-dialog-hide]') &&
         target.closest('[aria-modal="true"]') === this.$el)
     ) {
       this.hide(event)


### PR DESCRIPTION
So #387 is cool so that we can dynamically inject dialog closers (solving #367), but it also breaks support for having nested elements inside dialog openers/closers. This pull-request fixes that by using `.closest(..)` instead of `.matches(..)`. 

The only thing that remains a bit annoying is that we no longer have access to the `currentTarget` (the element on which the event listener is bound). We only have access to the `target` (the element that was interacted with).

Version 7: 

```js
dialog.on('show', (container, event) => {
  // `event.target` contains the interacted-with element, which may be a
  // child of the actual dialog opener. The opener itself is stored in
  // `event.currentTarget` (the element listening to click events).
  const opener = event.currentTarget
})
```

Version 8:

```js
dialog.on('show', event => {
  // `event.target` contains the dialog container since it’s where we dispatch
  // the custom event. `event.detail.target` contains the interacted-with
  // element, which may be a child of the actual dialog opener. The opener
  // itself is not stored anywhere and needs to be retrieved with `.closest(..)`.
  // That’s a mouthful…
  const opener = event.detail.target.closest('[data-a11y-dialog-show]')
})
```

Documentation gets addressed in #456.