### PR TITLE
[Version 8] Handle Shadow DOM subtrees when checking for active element

### DIFF
--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -52,7 +52,7 @@ export default class A11yDialog {
 
     // Keep a reference to the currently focused element to be able to restore
     // it later
-    this.previouslyFocused = document.activeElement as HTMLElement
+    this.previouslyFocused = getDeepActiveElement() as HTMLElement
     this.shown = true
     this.$el.removeAttribute('aria-hidden')
 
@@ -307,26 +307,24 @@ function isFocusable(el: HTMLElement) {
  */
 function trapTabKey(el: HTMLElement, event: KeyboardEvent) {
   const focusableChildren = getFocusableChildren(el)
-  const focusedItemIndex = focusableChildren.indexOf(
-    document.activeElement as HTMLElement
-  )
+  const firstFocusableChild = focusableChildren[0]
+  const lastFocusableChild = focusableChildren[focusableChildren.length - 1]
+
+  const activeElement = getDeepActiveElement()
 
   // If the SHIFT key is pressed while tabbing (moving backwards) and the
   // currently focused item is the first one, move the focus to the last
   // focusable item from the dialog element
-  if (event.shiftKey && focusedItemIndex === 0) {
-    focusableChildren[focusableChildren.length - 1].focus()
+  if (event.shiftKey && activeElement === firstFocusableChild) {
+    lastFocusableChild.focus()
     event.preventDefault()
   }
 
   // If the SHIFT key is not pressed (moving forwards) and the currently focused
   // item is the last one, move the focus to the first focusable item from the
   // dialog element
-  else if (
-    !event.shiftKey &&
-		event.target === focusableChildren[focusableChildren.length - 1]
-  ) {
-    focusableChildren[0].focus()
+  else if (!event.shiftKey && activeElement === lastFocusableChild) {
+    firstFocusableChild.focus()
     event.preventDefault()
   }
 }

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -52,7 +52,7 @@ export default class A11yDialog {
 
     // Keep a reference to the currently focused element to be able to restore
     // it later
-    this.previouslyFocused = getDeepActiveElement() as HTMLElement
+    this.previouslyFocused = getActiveElement() as HTMLElement
     this.shown = true
     this.$el.removeAttribute('aria-hidden')
 
@@ -310,7 +310,7 @@ function trapTabKey(el: HTMLElement, event: KeyboardEvent) {
   const firstFocusableChild = focusableChildren[0]
   const lastFocusableChild = focusableChildren[focusableChildren.length - 1]
 
-  const activeElement = getDeepActiveElement()
+  const activeElement = getActiveElement()
 
   // If the SHIFT key is pressed while tabbing (moving backwards) and the
   // currently focused item is the first one, move the focus to the last
@@ -330,9 +330,9 @@ function trapTabKey(el: HTMLElement, event: KeyboardEvent) {
 }
 
 // Get the active element, accounting for Shadow DOM subtrees.
-// Credit to Cory LaViska for this inmplementation
+// Credit to Cory LaViska for this implementation
 // @see: https://www.abeautifulsite.net/posts/finding-the-active-element-in-a-shadow-root/
-function getDeepActiveElement(
+function getActiveElement(
   root: Document | ShadowRoot = document
 ): Element | null {
   const activeEl = root.activeElement
@@ -343,7 +343,7 @@ function getDeepActiveElement(
 
   // If there's a shadow root, recursively look for the active element within it
   if (activeEl.shadowRoot) {
-    return getDeepActiveElement(activeEl.shadowRoot)
+    return getActiveElement(activeEl.shadowRoot)
     // If not, we can just return the active element
   } else {
     return activeEl

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -308,7 +308,7 @@ function isFocusable(el: HTMLElement) {
 function trapTabKey(el: HTMLElement, event: KeyboardEvent) {
   const focusableChildren = getFocusableChildren(el)
   const firstFocusableChild = focusableChildren[0]
-  const lastFocusableChild = focusableChildren[focusableChildren.length - 1]
+  const lastFocusableChild = focusableChildren.at(-1)
 
   const activeElement = getActiveElement()
 

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -324,10 +324,31 @@ function trapTabKey(el: HTMLElement, event: KeyboardEvent) {
   // dialog element
   else if (
     !event.shiftKey &&
-    focusedItemIndex === focusableChildren.length - 1
+		event.target === focusableChildren[focusableChildren.length - 1]
   ) {
     focusableChildren[0].focus()
     event.preventDefault()
+  }
+}
+
+// Get the active element, accounting for Shadow DOM subtrees.
+// Credit to Cory LaViska for this inmplementation
+// @see: https://www.abeautifulsite.net/posts/finding-the-active-element-in-a-shadow-root/
+function getDeepActiveElement(
+  root: Document | ShadowRoot = document
+): Element | null {
+  const activeEl = root.activeElement
+
+  if (!activeEl) {
+    return null
+  }
+
+  // If there's a shadow root, recursively look for the active element within it
+  if (activeEl.shadowRoot) {
+    return getDeepActiveElement(activeEl.shadowRoot)
+    // If not, we can just return the active element
+  } else {
+    return activeEl
   }
 }
 


### PR DESCRIPTION
(text copied from #458, which was closed by accident)

## Summary
This PR adds further support for Shadow DOM and custom elements, following work in #397. Note: it depends on changes in #455, so that should merge first.

Without these changes, our `trapTabKey` function doesn't understand when the user's focus is in a shadow subtree, so the user could escape the modal when we don't want them to.

## Why?

`document.activeElement` is not aware of any shadow roots in the document. We have to check for shadow roots on the active element, then get the active element within that root. See `getDeepActiveElement()`.