### PR TITLE
add documentation section on VoiceOver aria-labelledby issue

### DIFF
--- a/docs/further_reading.known_issues.md
+++ b/docs/further_reading.known_issues.md
@@ -15,6 +15,12 @@ It is unclear whether this is still an issue. It was reported a long time ago an
 
 Content with `aria-hidden` appears to be sometimes read by VoiceOver on iOS and macOS. It is unclear in which case this happens, and does not appear to be an issue directly related to the library. Refer to this [WebKit bug](https://bugs.webkit.org/show_bug.cgi?id=201887#c2) for reference.
 
+## aria-labelledby announcement on VoiceOver
+
+The dialog name associated via `aria-labelledby` is not read by VoiceOver in Chrome and FireFox (but is in Safari). This peculiar behavior appears when the close button is located before the dialog name.
+
+Making sure the element associated with `aria-labelledby` comes as a first child of the dialog is a simple workaround to this minor issue.
+
 ## Mobile issues
 
 The library relies on `aria-modal`, a standardized attribute from [WAI-ARIA 1.1](https://www.w3.org/TR/wai-aria-1.1/#aria-modal). Unfortunately, the [support for this attribute](https://a11ysupport.io/tech/aria/aria-modal_attribute) is not incredible with certain mobile assistive technologies, as reported in [issue #408](https://github.com/KittyGiraudel/a11y-dialog/pull/408). If that’s an issue for you, you have two equally viable options:

--- a/versioned_docs/version-6.1.0/further_reading.known_issues.md
+++ b/versioned_docs/version-6.1.0/further_reading.known_issues.md
@@ -11,6 +11,12 @@ It has been reported that the focus restoration to the formerly active element w
 
 Content with `aria-hidden` appears to be sometimes read by VoiceOver on iOS and macOS. It is unclear in which case this happens, and does not appear to be an issue directly related to the library. Refer to this [WebKit bug](https://bugs.webkit.org/show_bug.cgi?id=201887#c2) for reference.
 
+## aria-labelledby announcement on VoiceOver
+
+The dialog name associated via `aria-labelledby` is not read by VoiceOver in Chrome and FireFox (but is in Safari). This peculiar behavior appears when the close button is located before the dialog name.
+
+Making sure the element associated with `aria-labelledby` comes as a first child of the dialog is a simple workaround to this minor issue.
+
 ## Shadow DOM
 
 The algorithm to trap the focus within the dialog does not take into account shadow DOM trees. This can be an issue when the first or lass focusable element within the dialog is a web component. Refer to [issue #322](https://github.com/KittyGiraudel/a11y-dialog/issues/322) as a reference.

--- a/versioned_docs/version-7.0.0/further_reading.known_issues.md
+++ b/versioned_docs/version-7.0.0/further_reading.known_issues.md
@@ -15,6 +15,12 @@ It is unclear whether this is still an issue. It was reported a long time ago an
 
 Content with `aria-hidden` appears to be sometimes read by VoiceOver on iOS and macOS. It is unclear in which case this happens, and does not appear to be an issue directly related to the library. Refer to this [WebKit bug](https://bugs.webkit.org/show_bug.cgi?id=201887#c2) for reference.
 
+## aria-labelledby announcement on VoiceOver
+
+The dialog name associated via `aria-labelledby` is not read by VoiceOver in Chrome and FireFox (but is in Safari). This peculiar behavior appears when the close button is located before the dialog name.
+
+Making sure the element associated with `aria-labelledby` comes as a first child of the dialog is a simple workaround to this minor issue.
+
 ## Shadow DOM
 
 As reported in [issue #322](https://github.com/KittyGiraudel/a11y-dialog/issues/322), a11y-dialog fails to account for shadow DOM when trapping the focus. This can be a problem when rendering interactive web components within the dialog.


### PR DESCRIPTION
Add a section on VoiceOver issue related to `aria-labeledby`. Based on the discussion in #454.