### PR TITLE
[Version 8] Test dialogs with Shadow DOM subtree

### DIFF
--- a/cypress/e2e/focus.cy.js
+++ b/cypress/e2e/focus.cy.js
@@ -23,7 +23,7 @@ describe('Focus', { testIsolation: false }, () => {
   })
 
   it('should restore focus to the previously focused element', () => {
-    cy.get('.dialog-close').click()
+    cy.get('#close-my-dialog').click()
     cy.get('[data-a11y-dialog-show="my-dialog"]').should('have.focus')
   })
 
@@ -31,5 +31,29 @@ describe('Focus', { testIsolation: false }, () => {
     cy.get('[data-a11y-dialog-show="my-dialog"]').click()
     cy.get('#move-focus-outside').click()
     cy.get('#focus-me').should('have.focus')
+
+    // Close the open dialog
+    cy.get('#close-my-dialog').click()
+  })
+
+  it('Should properly handle focus with Shadow DOM children', () => {
+    cy.get('[data-a11y-dialog-show="shadow-dialog"]').click()
+
+    // Move focus into the dialog
+    // and ensure that the first focused element
+    // is a <fancy-button>
+    cy.realPress('Tab')
+      .focused()
+      .then($el => {
+        expect($el[0].tagName).to.equal('FANCY-BUTTON')
+      })
+
+    // Verify that focus goes backward into the <fancy-card> element.
+    // Wthin that, verify that the <fancy-button> element is focused.
+    cy.realPress(['Shift', 'Tab'])
+      .focused()
+      .shadow()
+      .find('fancy-button')
+      .should('have.focus')
   })
 })

--- a/cypress/e2e/focus.cy.js
+++ b/cypress/e2e/focus.cy.js
@@ -55,5 +55,21 @@ describe('Focus', { testIsolation: false }, () => {
       .shadow()
       .find('fancy-button')
       .should('have.focus')
+
+    // Close the open dialog
+    cy.get('#close-shadow-dialog').click()
+  })
+
+  it('Should properly handle focus when the first or last child is a focusable shadow host', () => {
+    cy.get('[data-a11y-dialog-show="focusable-shadow-host-dialog"]').click()
+
+    cy.realPress('Tab')
+      .realPress(['Shift', 'Tab'])
+      .focused()
+      .then($el => {
+        const el = $el[0]
+        expect(el.getAttribute('tabindex')).to.equal('0')
+        expect(el.tagName).to.equal('FANCY-DIV')
+      })
   })
 })

--- a/cypress/fixtures/base.html
+++ b/cypress/fixtures/base.html
@@ -165,9 +165,9 @@
     <style>
       :host { contain: content; display: inline-block; }
     </style>
-    <span>
+    <div>
       <slot></slot>
-    </span>
+    </div>
   `
           }
         }

--- a/cypress/fixtures/base.html
+++ b/cypress/fixtures/base.html
@@ -5,25 +5,6 @@
   <meta charset="utf-8">
   <title>Tests — Base</title>
   <link rel="stylesheet" href="../styles.css" />
-  <style>
-    fancy-button.dialog-close::part(root) {
-      background-color: transparent;
-      border: none;
-      color: black;
-      font-weight: bold;
-      padding-inline: 0.25em;
-    }
-    fancy-div {
-      border: 2px solid #005ec2;
-      border-radius: 4px;
-      margin-top: .5em;
-      padding: 0.25em 0.75em;
-    }
-    fancy-div:focus {
-      outline: 2px solid tomato;
-      outline-offset: 2px;
-    }
-  </style>
 </head>
 
 <body>
@@ -36,6 +17,7 @@
     <button class="link-like" data-a11y-dialog-show="shadow-dialog">
       Open the shadow dialog
     </button>
+    <button class="link-like" data-a11y-dialog-show="edge-case-dialog">Open the edge case dialog</button>
   </main>
 
   <div class="dialog" data-a11y-dialog="my-dialog" aria-labelledby="my-dialog-title">
@@ -78,6 +60,29 @@
         </fancy-card>
       </div>
     </div>
+    <div
+      class="dialog"
+      data-a11y-dialog="edge-case-dialog"
+      aria-labelledby="edge-case-dialog-title"
+    >
+      <div class="dialog-overlay" data-a11y-dialog-hide></div>
+      <div class="dialog-content" role="document">
+        <fancy-button
+          data-a11y-dialog-hide
+          id="close-edge-case-dialog"
+          class="dialog-close"
+          aria-label="Close edge case dialog"
+        >
+          &times;
+        </fancy-button>
+
+        <h1 id="edge-case-dialog-title">Dialog with an edge case</h1>
+        <a href="#" class="link-like">A link</a>
+        <fancy-div tabindex="0">
+          I'm a focusable Shadow Dom element, and I'm last in the DOM!
+        </fancy-div>
+      </div>
+    </div>
 
   <div data-a11y-dialog-ignore-focus-trap>
     <button type="button" id="focus-me">Focus me</button>
@@ -89,15 +94,15 @@
       document.querySelector('#focus-me').focus()
     })
 
-    window.customElements.define(
-      'fancy-button',
-      class FancyButton extends HTMLElement {
-        constructor() {
-          super()
-          this.attachShadow({
-            delegatesFocus: true,
-            mode: 'open',
-          }).innerHTML = `
+      window.customElements.define(
+        'fancy-button',
+        class FancyButton extends HTMLElement {
+          constructor() {
+            super()
+            this.attachShadow({
+              delegatesFocus: true,
+              mode: 'open',
+            }).innerHTML = `
     <style>
       *:focus-visible {outline: 2px solid #005ec2; outline-offset: 2px}
       :host { display: inline-block; }
@@ -115,17 +120,17 @@
     </style>
     <button part="root"><slot></slot></button>
   `
+          }
         }
-      }
-    )
-    window.customElements.define(
-      'fancy-card',
-      class MyCard extends HTMLElement {
-        constructor() {
-          super()
-          this.attachShadow({
-            mode: 'open',
-          }).innerHTML = `
+      )
+      window.customElements.define(
+        'fancy-card',
+        class MyCard extends HTMLElement {
+          constructor() {
+            super()
+            this.attachShadow({
+              mode: 'open',
+            }).innerHTML = `
     <style>
       :host  { contain: content; margin-block: 1em; }
       .container {
@@ -146,17 +151,17 @@
       <fancy-button>I'm in the card's Shadow DOM</fancy-button>
     </div>
   `
+          }
         }
-      }
-    )
-    window.customElements.define(
-      'fancy-div',
-      class MyCard extends HTMLElement {
-        constructor() {
-          super()
-          this.attachShadow({
-            mode: 'open',
-          }).innerHTML = `
+      )
+      window.customElements.define(
+        'fancy-div',
+        class MyCard extends HTMLElement {
+          constructor() {
+            super()
+            this.attachShadow({
+              mode: 'open',
+            }).innerHTML = `
     <style>
       :host { contain: content; display: inline-block; }
     </style>
@@ -164,9 +169,9 @@
       <slot></slot>
     </span>
   `
+          }
         }
-      }
-    )
+      )
   </script>
 </body>
 

--- a/cypress/fixtures/base.html
+++ b/cypress/fixtures/base.html
@@ -17,7 +17,7 @@
     <button class="link-like" data-a11y-dialog-show="shadow-dialog">
       Open the shadow dialog
     </button>
-    <button class="link-like" data-a11y-dialog-show="edge-case-dialog">Open the edge case dialog</button>
+    <button class="link-like" data-a11y-dialog-show="focusable-shadow-host-dialog">Open the focusable shadow host dialog</button>
   </main>
 
   <div class="dialog" data-a11y-dialog="my-dialog" aria-labelledby="my-dialog-title">
@@ -62,21 +62,21 @@
     </div>
     <div
       class="dialog"
-      data-a11y-dialog="edge-case-dialog"
-      aria-labelledby="edge-case-dialog-title"
+      data-a11y-dialog="focusable-shadow-host-dialog"
+      aria-labelledby="focusable-shadow-host-dialog-title"
     >
       <div class="dialog-overlay" data-a11y-dialog-hide></div>
       <div class="dialog-content" role="document">
         <fancy-button
           data-a11y-dialog-hide
-          id="close-edge-case-dialog"
+          id="close-focusable-shadow-host-dialog"
           class="dialog-close"
-          aria-label="Close edge case dialog"
+          aria-label="Close focusable shadow host dialog"
         >
           &times;
         </fancy-button>
 
-        <h1 id="edge-case-dialog-title">Dialog with an edge case</h1>
+        <h1 id="focusable-shadow-host-dialog-title">Dialog with an focusable shadow host</h1>
         <a href="#" class="link-like">A link</a>
         <fancy-div tabindex="0">
           I'm a focusable Shadow Dom element, and I'm last in the DOM!

--- a/cypress/fixtures/base.html
+++ b/cypress/fixtures/base.html
@@ -5,6 +5,25 @@
   <meta charset="utf-8">
   <title>Tests — Base</title>
   <link rel="stylesheet" href="../styles.css" />
+  <style>
+    fancy-button.dialog-close::part(root) {
+      background-color: transparent;
+      border: none;
+      color: black;
+      font-weight: bold;
+      padding-inline: 0.25em;
+    }
+    fancy-div {
+      border: 2px solid #005ec2;
+      border-radius: 4px;
+      margin-top: .5em;
+      padding: 0.25em 0.75em;
+    }
+    fancy-div:focus {
+      outline: 2px solid tomato;
+      outline-offset: 2px;
+    }
+  </style>
 </head>
 
 <body>
@@ -14,13 +33,15 @@
       <!-- Insert a needless span here to make sure delegated clicks work -->
       <span>Open the dialog window</span>
     </button>
-    <button class="link-like" data-a11y-dialog-show="something-else">Open the dialog window</button>
+    <button class="link-like" data-a11y-dialog-show="shadow-dialog">
+      Open the shadow dialog
+    </button>
   </main>
 
   <div class="dialog" data-a11y-dialog="my-dialog" aria-labelledby="my-dialog-title">
     <div class="dialog-overlay" data-a11y-dialog-hide></div>
     <div class="dialog-content" role="document">
-      <button data-a11y-dialog-hide class="dialog-close" aria-label="Close this dialog window">&times;</button>
+      <button data-a11y-dialog-hide id="close-my-dialog" class="dialog-close" aria-label="Close this dialog window">&times;</button>
 
       <h1 id="my-dialog-title">Dialog title</h1>
 
@@ -33,6 +54,30 @@
       <button type="button" id="move-focus-outside">Move focus outside</button>
     </div>
   </div>
+  <div
+      class="dialog"
+      data-a11y-dialog="shadow-dialog"
+      aria-labelledby="shadow-dialog-title"
+    >
+      <div class="dialog-overlay" data-a11y-dialog-hide></div>
+      <div class="dialog-content" role="document">
+        <fancy-button
+          data-a11y-dialog-hide
+          id="close-shadow-dialog"
+          class="dialog-close"
+          aria-label="Close shadow dialog"
+        >
+          &times;
+        </fancy-button>
+
+        <h1 id="shadow-dialog-title">Dialog with shadow children</h1>
+        <fancy-card>
+          <h2 style="margin-block-start: 0">A fancy card</h2>
+          <p>I'm Light DOM text</p>
+          <a href="#" class="link-like">I'm a Light Dom link</a>
+        </fancy-card>
+      </div>
+    </div>
 
   <div data-a11y-dialog-ignore-focus-trap>
     <button type="button" id="focus-me">Focus me</button>
@@ -43,6 +88,85 @@
     document.querySelector('#move-focus-outside').addEventListener('click', () => {
       document.querySelector('#focus-me').focus()
     })
+
+    window.customElements.define(
+      'fancy-button',
+      class FancyButton extends HTMLElement {
+        constructor() {
+          super()
+          this.attachShadow({
+            delegatesFocus: true,
+            mode: 'open',
+          }).innerHTML = `
+    <style>
+      *:focus-visible {outline: 2px solid #005ec2; outline-offset: 2px}
+      :host { display: inline-block; }
+      button {
+        appareance: none;
+        border: 2px solid #005ec2;
+        border-radius: 4px;
+        background-color: #007bff;
+        color: white;
+        cursor: pointer;
+        display: inline-block;
+        font-size: inherit;
+        padding: 0.25em 0.75em;
+      }
+    </style>
+    <button part="root"><slot></slot></button>
+  `
+        }
+      }
+    )
+    window.customElements.define(
+      'fancy-card',
+      class MyCard extends HTMLElement {
+        constructor() {
+          super()
+          this.attachShadow({
+            mode: 'open',
+          }).innerHTML = `
+    <style>
+      :host  { contain: content; margin-block: 1em; }
+      .container {
+        background-color: aliceblue;
+        border: 1px solid skyblue;
+        border-radius: 4px;
+        display: flex;
+        flex-direction: column;
+        margin-top: 1em;
+        padding: 0.5em;
+      }
+      .container > * + * { margin-top: 1em; }
+      a { display: inline-block }
+      p { margin: 0 }
+    </style>
+    <div class="container">
+      <slot></slot>
+      <fancy-button>I'm in the card's Shadow DOM</fancy-button>
+    </div>
+  `
+        }
+      }
+    )
+    window.customElements.define(
+      'fancy-div',
+      class MyCard extends HTMLElement {
+        constructor() {
+          super()
+          this.attachShadow({
+            mode: 'open',
+          }).innerHTML = `
+    <style>
+      :host { contain: content; display: inline-block; }
+    </style>
+    <span>
+      <slot></slot>
+    </span>
+  `
+        }
+      }
+    )
   </script>
 </body>
 

--- a/cypress/fixtures/styles.css
+++ b/cypress/fixtures/styles.css
@@ -163,7 +163,7 @@ fancy-button.dialog-close::part(root) {
   padding-inline: 0.25em;
 }
 fancy-div {
-  border: 2px solid #005ec2;
+  background-color: #e0e0e0;
   border-radius: 4px;
   margin-top: 0.5em;
   padding: 0.25em 0.75em;

--- a/cypress/fixtures/styles.css
+++ b/cypress/fixtures/styles.css
@@ -118,10 +118,16 @@
 }
 
 body {
+  align-items: stretch;
+  display: flex;
+  flex-direction: column;
   font: 125% / 1.5 -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
     sans-serif;
+  gap: 1em;
   padding: 2em 0;
 }
+
+
 
 h1 {
   font-size: 1.6em;
@@ -149,6 +155,24 @@ a:active {
   color: #e50050;
 }
 
+fancy-button.dialog-close::part(root) {
+  background-color: transparent;
+  border: none;
+  color: black;
+  font-weight: bold;
+  padding-inline: 0.25em;
+}
+fancy-div {
+  border: 2px solid #005ec2;
+  border-radius: 4px;
+  margin-top: 0.5em;
+  padding: 0.25em 0.75em;
+}
+fancy-div:focus {
+  outline: 2px solid tomato;
+  outline-offset: 2px;
+}
+
 /* -------------------------------------------------------------------------- *\
  * Helpers
  * -------------------------------------------------------------------------- */
@@ -168,9 +192,13 @@ a:active {
  * -------------------------------------------------------------------------- */
 
 main {
-  max-width: 700px;
-  margin: 0 auto;
-  padding: 0 1em;
+  align-items: flex-start;
+  display: flex;
+	flex-basis: 100%;
+  flex-direction: column;
+  gap: 0.5em;
+	margin: 0;
+	padding: 0 1em;
 }
 
 footer {


### PR DESCRIPTION
## Summary
Following work in #459, these tests provide us some security in the way we support Shadow DOM. Note that the final new test (`'Should properly handle focus when the first or last child is a focusable shadow host'`) _does not pass_ yet; I noticed a gap in the current algorithm and wanted to cover it. I will follow up with a patch that also optimizes the algorithm.

## Screenshots
Our handsome new test modals!
<img width="620" alt="CleanShot 2023-01-22 at 00 40 10@2x" src="https://user-images.githubusercontent.com/13525251/213942015-cc4ea397-b271-4196-9c30-2dc912e90e04.png">
<img width="620" alt="CleanShot 2023-01-22 at 06 04 57@2x" src="https://user-images.githubusercontent.com/13525251/213942017-f07c4588-1951-4379-b1ea-73818a3c173d.png">
(this is the one whose tests do not pass)

## Misc. changes
Some styling for the test fixtures :)
