### PR TITLE
[Version 8] Optimize algorithm for tracking focusable children of dialog

### DIFF
--- a/cypress/e2e/focus.cy.js
+++ b/cypress/e2e/focus.cy.js
@@ -58,7 +58,6 @@ describe('Focus', { testIsolation: false }, () => {
     cy.get('#close-shadow-dialog').click()
   })
 
-  // @TODO: Currently not working and needs fixing
   it('should properly handle focus when the first or last child is a focusable shadow host', () => {
     cy.get('[data-a11y-dialog-show="focusable-shadow-host-dialog"]').click()
 

--- a/cypress/e2e/focus.cy.js
+++ b/cypress/e2e/focus.cy.js
@@ -59,7 +59,7 @@ describe('Focus', { testIsolation: false }, () => {
   })
 
   // @TODO: Currently not working and needs fixing
-  it.skip('should properly handle focus when the first or last child is a focusable shadow host', () => {
+  it('should properly handle focus when the first or last child is a focusable shadow host', () => {
     cy.get('[data-a11y-dialog-show="focusable-shadow-host-dialog"]').click()
 
     cy.realPress('Tab').realPress(['Shift', 'Tab']).focused().as('focused')

--- a/cypress/fixtures/focus.html
+++ b/cypress/fixtures/focus.html
@@ -14,9 +14,9 @@
       <!-- Insert a needless span here to make sure delegated clicks work -->
       <span>Open the dialog window</span>
     </button>
-    <button class="link-like" data-a11y-dialog-show="shadow-dialog">
+    <fancy-div class="link-like" data-a11y-dialog-show="shadow-dialog" tabindex="0">
       Open the shadow dialog
-    </button>
+    </fancy-div>
     <button class="link-like" data-a11y-dialog-show="focusable-shadow-host-dialog">Open the focusable shadow host
       dialog</button>
   </main>

--- a/cypress/fixtures/focus.html
+++ b/cypress/fixtures/focus.html
@@ -5,6 +5,13 @@
   <meta charset="utf-8">
   <title>Tests — Base</title>
   <link rel="stylesheet" href="../styles.css" />
+	<style>
+		[inert] {
+			pointer-events: none;
+			background-color: antiquewhite;
+			opacity: 0.5;
+		}
+	</style>
 </head>
 
 <body>
@@ -27,15 +34,9 @@
       <button data-a11y-dialog-hide id="close-my-dialog" class="dialog-close"
         aria-label="Close this dialog window">&times;</button>
 
-      <h1 id="my-dialog-title">Dialog title</h1>
-
-      <form>
-        <label for="email">Email (required)</label>
-        <input type="email" name="EMAIL" id="email" placeholder="john.doe@gmail.com" required>
-        <button type="submit" name="button">Sign up</button>
-      </form>
-
-      <button type="button" id="move-focus-outside">Move focus outside</button>
+      <h1 id="my-dialog-title" hidden>Dialog title</h1>
+      <button type="button" id="move-focus-outside">Confirm</button>
+			<div inert><a href="#">I'm an anchor</a></div>
     </div>
   </div>
   <div class="dialog" data-a11y-dialog="shadow-dialog" aria-labelledby="shadow-dialog-title">

--- a/cypress/fixtures/focus.html
+++ b/cypress/fixtures/focus.html
@@ -5,13 +5,6 @@
   <meta charset="utf-8">
   <title>Tests — Base</title>
   <link rel="stylesheet" href="../styles.css" />
-	<style>
-		[inert] {
-			pointer-events: none;
-			background-color: antiquewhite;
-			opacity: 0.5;
-		}
-	</style>
 </head>
 
 <body>
@@ -34,9 +27,15 @@
       <button data-a11y-dialog-hide id="close-my-dialog" class="dialog-close"
         aria-label="Close this dialog window">&times;</button>
 
-      <h1 id="my-dialog-title" hidden>Dialog title</h1>
-      <button type="button" id="move-focus-outside">Confirm</button>
-			<div inert><a href="#">I'm an anchor</a></div>
+      <h1 id="my-dialog-title">Dialog title</h1>
+
+      <form>
+        <label for="email">Email (required)</label>
+        <input type="email" name="EMAIL" id="email" placeholder="john.doe@gmail.com" required>
+        <button type="submit" name="button">Sign up</button>
+      </form>
+
+      <button type="button" id="move-focus-outside">Move focus outside</button>
     </div>
   </div>
   <div class="dialog" data-a11y-dialog="shadow-dialog" aria-labelledby="shadow-dialog-title">

--- a/cypress/fixtures/focus.html
+++ b/cypress/fixtures/focus.html
@@ -14,7 +14,7 @@
       <!-- Insert a needless span here to make sure delegated clicks work -->
       <span>Open the dialog window</span>
     </button>
-    <button class="link-like" data-a11y-dialog-show="shadow-dialog" tabindex="0">
+    <button class="link-like" data-a11y-dialog-show="shadow-dialog">
       Open the shadow dialog
     </button>
     <button class="link-like" data-a11y-dialog-show="focusable-shadow-host-dialog">Open the focusable shadow host

--- a/cypress/fixtures/focus.html
+++ b/cypress/fixtures/focus.html
@@ -14,9 +14,9 @@
       <!-- Insert a needless span here to make sure delegated clicks work -->
       <span>Open the dialog window</span>
     </button>
-    <fancy-div class="link-like" data-a11y-dialog-show="shadow-dialog" tabindex="0">
+    <button class="link-like" data-a11y-dialog-show="shadow-dialog" tabindex="0">
       Open the shadow dialog
-    </fancy-div>
+		</button>
     <button class="link-like" data-a11y-dialog-show="focusable-shadow-host-dialog">Open the focusable shadow host
       dialog</button>
   </main>

--- a/cypress/fixtures/focus.html
+++ b/cypress/fixtures/focus.html
@@ -16,7 +16,7 @@
     </button>
     <button class="link-like" data-a11y-dialog-show="shadow-dialog" tabindex="0">
       Open the shadow dialog
-		</button>
+    </button>
     <button class="link-like" data-a11y-dialog-show="focusable-shadow-host-dialog">Open the focusable shadow host
       dialog</button>
   </main>

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -1,6 +1,6 @@
 import {
   getActiveElement,
-  getFirstAndLastFocusableChild,
+  getFocusableEdges,
   moveFocusToDialog,
 } from './dom-utils'
 
@@ -221,8 +221,7 @@ function $$(selector: string, context: ParentNode = document): HTMLElement[] {
  * Trap the focus inside the given element
  */
 function trapTabKey(el: HTMLElement, event: KeyboardEvent) {
-  const [firstFocusableChild, lastFocusableChild] =
-    getFirstAndLastFocusableChild(el)
+  const [firstFocusableChild, lastFocusableChild] = getFocusableEdges(el)
 
   if (!firstFocusableChild || !lastFocusableChild) return
 

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -226,7 +226,7 @@ function trapTabKey(el: HTMLElement, event: KeyboardEvent) {
 
   if (!firstFocusableChild || !lastFocusableChild) return
 
-  const activeElement = getActiveElement()
+  const activeElement = getActiveElement() || document.activeElement
 
   // If the SHIFT key is pressed while tabbing (moving backwards) and the
   // currently focused item is the first one, move the focus to the last

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -1,6 +1,6 @@
 import {
   getActiveElement,
-  getFocusableChildren,
+  getFirstAndLastFocusableChild,
   moveFocusToDialog,
 } from './dom-utils'
 
@@ -221,9 +221,10 @@ function $$(selector: string, context: ParentNode = document): HTMLElement[] {
  * Trap the focus inside the given element
  */
 function trapTabKey(el: HTMLElement, event: KeyboardEvent) {
-  const focusableChildren = getFocusableChildren(el)
-  const firstFocusableChild = focusableChildren[0]
-  const lastFocusableChild = focusableChildren.at(-1)
+  const [firstFocusableChild, lastFocusableChild] =
+    getFirstAndLastFocusableChild(el)
+
+  if (!firstFocusableChild || !lastFocusableChild) return
 
   const activeElement = getActiveElement()
 

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -56,8 +56,7 @@ export default class A11yDialog {
 
     // Keep a reference to the currently focused element to be able to restore
     // it later
-    this.previouslyFocused =
-      (getActiveElement() as HTMLElement) || document.activeElement
+    this.previouslyFocused = getActiveElement() as HTMLElement
     this.shown = true
     this.$el.removeAttribute('aria-hidden')
 
@@ -227,7 +226,7 @@ function trapTabKey(el: HTMLElement, event: KeyboardEvent) {
 
   if (!firstFocusableChild || !lastFocusableChild) return
 
-  const activeElement = getActiveElement() || document.activeElement
+  const activeElement = getActiveElement()
 
   // If the SHIFT key is pressed while tabbing (moving backwards) and the
   // currently focused item is the first one, move the focus to the last

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -221,9 +221,11 @@ function $$(selector: string, context: ParentNode = document): HTMLElement[] {
  * Trap the focus inside the given element
  */
 function trapTabKey(el: HTMLElement, event: KeyboardEvent) {
-  const [firstFocusableChild, lastFocusableChild] = getFocusableEdges(el)
+  const [firstFocusableChild, lastFocusableChild] = getFocusableEdges(el)!
 
-  if (!firstFocusableChild || !lastFocusableChild) return
+  // If there are no focusable children in the dialog,
+  // prevent the user from tabbing out of it
+  if (!firstFocusableChild || !lastFocusableChild) return event.preventDefault()
 
   const activeElement = getActiveElement()
 

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -221,7 +221,7 @@ function $$(selector: string, context: ParentNode = document): HTMLElement[] {
  * Trap the focus inside the given element
  */
 function trapTabKey(el: HTMLElement, event: KeyboardEvent) {
-  const [firstFocusableChild, lastFocusableChild] = getFocusableEdges(el)!
+  const [firstFocusableChild, lastFocusableChild] = getFocusableEdges(el)
 
   // If there are no focusable children in the dialog,
   // prevent the user from tabbing out of it

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -225,7 +225,7 @@ function trapTabKey(el: HTMLElement, event: KeyboardEvent) {
 
   // If there are no focusable children in the dialog,
   // prevent the user from tabbing out of it
-  if (!firstFocusableChild || !lastFocusableChild) return event.preventDefault()
+  if (!firstFocusableChild) return event.preventDefault()
 
   const activeElement = getActiveElement()
 

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -56,7 +56,8 @@ export default class A11yDialog {
 
     // Keep a reference to the currently focused element to be able to restore
     // it later
-    this.previouslyFocused = getActiveElement() as HTMLElement
+    this.previouslyFocused =
+      (getActiveElement() as HTMLElement) || document.activeElement
     this.shown = true
     this.$el.removeAttribute('aria-hidden')
 

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -101,38 +101,12 @@ export function isFocusable(el: HTMLElement) {
   )
 }
 
-// Elements with these ARIA roles make their children `presentational`, which
-// nullifies their semantics
-// @see: https://www.w3.org/TR/wai-aria/
-const PRESENTATIONAL_CHILDREN_SELECTOR = [
-  'a[href]',
-  'button',
-  'img',
-  'summary',
-  '[role="button"]',
-  '[role="image"]',
-  '[role="link"]',
-  '[role="math"]',
-  '[role="presentation"]',
-  '[role="progressbar"]',
-  '[role="scrollbar"]',
-  '[role="slider"]',
-].join(',')
-
-// Elemments matching these selectors are either hidden entirely from the user,
-// or are visible but unavailable for interaction.
-// Neither they nor any of their descentants can ever receive focus.
-const HIDDEN_FROM_USER_SELECTOR =
-  ':disabled,[aria-disabled="true"],[aria-hidden="true"],[hidden],[inert]'
-
-const cannotHaveFocusableChildrenSelector =
-  PRESENTATIONAL_CHILDREN_SELECTOR + ',' + HIDDEN_FROM_USER_SELECTOR
-
 /**
  * Determine if an element can have focusable children. Useful for bailing out
- * early when walking the DOM tree.
- * @example:
- * The following div is inert, so none of its children can be focused,
+ * early when walking the DOM tree. Note: while this check has some overlap with
+ * `isFocusable`, its goal is to bail on an entire subtree, so it has to happen * at a different time.
+ * @example
+ * This div is inert, so none of its children can be focused,
  * even though they meet our criteria for what is focusable.
  * Once we check the div, we can skip the rest of the subtree.
  * ```html
@@ -141,18 +115,12 @@ const cannotHaveFocusableChildrenSelector =
  *   <a href="#">Link</a>
  * </div>
  * ```
- * This is bad HTML. Links make their children presentaional, so
- * the nested link is not available to the user. We bail out on the
- * parent link so we don't mistakenly consider the nested link focusable.
- * ```html
- * <a href="#">
- *   Hello,
- *   <a href="#">world</a>
- * </a>
- * ```
  */
 function canHaveFocusableChildren(el: HTMLElement) {
-  return !el.matches(cannotHaveFocusableChildrenSelector)
+  // Elemments matching this selector are either hidden entirely
+  //from the user, or are visible but unavailable for interaction.
+  // Their descentants can never receive focus.
+  return !el.matches(':disabled,[hidden],[inert]')
 }
 
 // Get the active element, accounting for Shadow DOM subtrees.

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -35,46 +35,43 @@ function findFocusableElement(
   }
 
   // If this node can't have focusable children, there's no point
-  // in checking its subtree, even if it it contains nodes that
-  // would otherwise be focusable.
-  if (!canHaveFocusableChildren(node)) {
-    return null
-  }
-
-  // Start walking the DOM tree, looking for focusable elements.
-  // Case 1: If this node has a shadow root, search it recursively.
-  if (node.shadowRoot) {
-    const shadowRoot = node.shadowRoot
-    // Descend into this subtree.
-    let next = getNextDescendantEl(shadowRoot, forward)
-    // Traverse siblings, searching the subtree of each one
-    // for focusable elements.
-    while (next) {
-      const focusableEl = findFocusableElement(next as HTMLElement, forward)
-      if (focusableEl) return focusableEl
-      next = getNextSiblingEl(next as HTMLElement, forward)
-    }
-    // Case 2: If this node is a slot for a Custom Element,
-    // search its assigned nodes recursively.
-  } else if (node.localName === 'slot') {
-    const assignedElements = (node as HTMLSlotElement).assignedElements({
-      flatten: true,
-    }) as HTMLElement[]
-    if (!forward) assignedElements.reverse()
-    for (const assignedElement of assignedElements) {
-      const focusableEl = findFocusableElement(assignedElement, forward)
-      if (focusableEl) return focusableEl
-    }
-    // Case 3: this is a regular Light DOM node. Search its subtree.
-  } else {
-    // Descend into this subtree.
-    let next = getNextDescendantEl(node, forward)
-    // Traverse siblings, searching the subtree of each one
-    // for focusable elements.
-    while (next) {
-      const focusableEl = findFocusableElement(next as HTMLElement, forward)
-      if (focusableEl) return focusableEl
-      next = getNextSiblingEl(next as HTMLElement, forward)
+  // in walking its subtree.
+  if (canHaveFocusableChildren(node)) {
+    // Start walking the DOM tree, looking for focusable elements.
+    // Case 1: If this node has a shadow root, search it recursively.
+    if (node.shadowRoot) {
+      const shadowRoot = node.shadowRoot
+      // Descend into this subtree.
+      let next = getNextDescendantEl(shadowRoot, forward)
+      // Traverse siblings, searching the subtree of each one
+      // for focusable elements.
+      while (next) {
+        const focusableEl = findFocusableElement(next as HTMLElement, forward)
+        if (focusableEl) return focusableEl
+        next = getNextSiblingEl(next as HTMLElement, forward)
+      }
+      // Case 2: If this node is a slot for a Custom Element,
+      // search its assigned nodes recursively.
+    } else if (node.localName === 'slot') {
+      const assignedElements = (node as HTMLSlotElement).assignedElements({
+        flatten: true,
+      }) as HTMLElement[]
+      if (!forward) assignedElements.reverse()
+      for (const assignedElement of assignedElements) {
+        const focusableEl = findFocusableElement(assignedElement, forward)
+        if (focusableEl) return focusableEl
+      }
+      // Case 3: this is a regular Light DOM node. Search its subtree.
+    } else {
+      // Descend into this subtree.
+      let next = getNextDescendantEl(node, forward)
+      // Traverse siblings, searching the subtree of each one
+      // for focusable elements.
+      while (next) {
+        const focusableEl = findFocusableElement(next as HTMLElement, forward)
+        if (focusableEl) return focusableEl
+        next = getNextSiblingEl(next as HTMLElement, forward)
+      }
     }
   }
 

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -42,7 +42,7 @@ function findFocusableElement(
     if (node.shadowRoot) {
       const shadowRoot = node.shadowRoot
       // Descend into this subtree.
-      let next = getNextDescendantEl(shadowRoot, forward)
+      let next = getNextChildEl(shadowRoot, forward)
       // Traverse siblings, searching the subtree of each one
       // for focusable elements.
       while (next) {
@@ -64,7 +64,7 @@ function findFocusableElement(
       // Case 3: this is a regular Light DOM node. Search its subtree.
     } else {
       // Descend into this subtree.
-      let next = getNextDescendantEl(node, forward)
+      let next = getNextChildEl(node, forward)
       // Traverse siblings, searching the subtree of each one
       // for focusable elements.
       while (next) {
@@ -83,7 +83,7 @@ function findFocusableElement(
   return null
 }
 
-function getNextDescendantEl(node: ParentNode, forward: boolean) {
+function getNextChildEl(node: ParentNode, forward: boolean) {
   return forward ? node.firstElementChild : node.lastElementChild
 }
 

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -41,7 +41,17 @@ function findFocusableElement(
   node: HTMLElement,
   forward: boolean
 ): HTMLElement | null {
-  if (forward && isFocusable(node)) return node
+  // If we're walking forward and this node is focusable,
+  // return it immediately.
+  if (forward && isFocusable(node)) {
+    return node
+  }
+
+  // If this node can't have focusable children, we can't go any deeper
+  // regardless of whether we're walking forward or backward.
+  if (!canHaveFocusableChildren(node)) {
+    return null
+  }
 
   const firstChild = forward ? 'firstElementChild' : 'lastElementChild'
   const siblingDirection = forward
@@ -92,6 +102,14 @@ export function isFocusable(el: HTMLElement) {
   return (
     el.matches(focusableSelectors.join(',')) &&
     !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length)
+  )
+}
+
+function canHaveFocusableChildren(el: HTMLElement) {
+  return !!(
+    el.matches(
+      '[hidden],[inert],:disabled,[aria-hidden="true"],[aria-disabled="true"]'
+    ) || !el.matches(PRESENTATIONAL_CHILDREN_SELECTOR)
   )
 }
 

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -54,11 +54,9 @@ function findFocusableElement(
   }
 
   // Start walking the DOM tree, looking for focusable elements.
-  // If we find one, return it immediately.
-
   // Case 1: If this node has a shadow root, search it recursively.
   if (node.shadowRoot) {
-    let shadowRoot = node.shadowRoot
+    const shadowRoot = node.shadowRoot
     // Descend into this subtree.
     let child = forward
       ? shadowRoot.firstElementChild

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -111,10 +111,10 @@ export function isFocusable(el: HTMLElement) {
 }
 
 function canHaveFocusableChildren(el: HTMLElement) {
-  return !!(
+  return !(
     el.matches(
       '[hidden],[inert],:disabled,[aria-hidden="true"],[aria-disabled="true"]'
-    ) || !el.matches(PRESENTATIONAL_CHILDREN_SELECTOR)
+    ) && el.matches(PRESENTATIONAL_CHILDREN_SELECTOR)
   )
 }
 

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -58,13 +58,13 @@ function findFocusableElement(
   if (node.shadowRoot) {
     const shadowRoot = node.shadowRoot
     // Descend into this subtree.
-    let child = getNextDescendantEl(shadowRoot, forward)
+    let next = getNextDescendantEl(shadowRoot, forward)
     // Traverse siblings, searching the subtree of each one
     // for focusable elements.
-    while (child) {
-      const focusableEl = findFocusableElement(child as HTMLElement, forward)
+    while (next) {
+      const focusableEl = findFocusableElement(next as HTMLElement, forward)
       if (focusableEl) return focusableEl
-      child = getNextSiblingEl(child as HTMLElement, forward)
+      next = getNextSiblingEl(next as HTMLElement, forward)
     }
     // Case 2: If this node is a slot for a Custom Element,
     // search its assigned nodes recursively.
@@ -80,13 +80,13 @@ function findFocusableElement(
     // Case 3: this is a regular Light DOM node. Search its subtree.
   } else {
     // Descend into this subtree.
-    let child = getNextDescendantEl(node, forward)
+    let next = getNextDescendantEl(node, forward)
     // Traverse siblings, searching the subtree of each one
     // for focusable elements.
-    while (child) {
-      const focusableEl = findFocusableElement(child as HTMLElement, forward)
+    while (next) {
+      const focusableEl = findFocusableElement(next as HTMLElement, forward)
       if (focusableEl) return focusableEl
-      child = getNextSiblingEl(child as HTMLElement, forward)
+      next = getNextSiblingEl(next as HTMLElement, forward)
     }
   }
 

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -47,8 +47,9 @@ function findFocusableElement(
     return node
   }
 
-  // If this node can't have focusable children, we can't go any deeper
-  // regardless of whether we're walking forward or backward.
+  // If this node can't have focusable children, there's no point
+  // in checking its subtree, even if it it contains nodes that
+  // would otherwise be focusable.
   if (!canHaveFocusableChildren(node)) {
     return null
   }
@@ -116,6 +117,29 @@ export function isFocusable(el: HTMLElement) {
   )
 }
 
+/**
+ * Determine if an element can have focusable children. Useful for bailing out
+ * early when walking the DOM tree.
+ * @example:
+ * The following div is inert, so none of its children can be focused,
+ * even though they meet our criteria for what is focusable.
+ * Once we check the div, we can skip the rest of the subtree.
+ * ```html
+ * <div inert>
+ *   <button>Button</button>
+ *   <a href="#">Link</a>
+ * </div>
+ * ```
+ * This is bad HTML. Links render their children presentaional, so
+ * the nested link has no meaning to the user. We bail out on the
+ * parent link so we don't mistakenly think the nested link is focusable.
+ * ```html
+ * <a href="#">
+ *   Hello,
+ *   <a href="#">world</a>
+ * </a>
+ * ```
+ */
 function canHaveFocusableChildren(el: HTMLElement) {
   return !(
     el.matches(

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -168,7 +168,8 @@ export function getActiveElement(
   if (!activeEl) return null
 
   // If there’s a shadow root, recursively find the active element within it.
-  // If the recursive call returns null, return the active element of the top-level Document.
+  // If the recursive call returns null, return the active element
+  // of the top-level Document.
   if (activeEl.shadowRoot)
     return getActiveElement(activeEl.shadowRoot) || document.activeElement
 

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -58,15 +58,13 @@ function findFocusableElement(
   if (node.shadowRoot) {
     const shadowRoot = node.shadowRoot
     // Descend into this subtree.
-    let child = forward
-      ? shadowRoot.firstElementChild
-      : shadowRoot.lastElementChild
+    let child = getNextDescendantEl(shadowRoot, forward)
     // Traverse siblings, searching the subtree of each one
     // for focusable elements.
     while (child) {
       const focusableEl = findFocusableElement(child as HTMLElement, forward)
       if (focusableEl) return focusableEl
-      child = forward ? child.nextElementSibling : child.previousElementSibling
+      child = getNextSiblingEl(child as HTMLElement, forward)
     }
     // Case 2: If this node is a slot for a Custom Element,
     // search its assigned nodes recursively.
@@ -82,13 +80,13 @@ function findFocusableElement(
     // Case 3: this is a regular Light DOM node. Search its subtree.
   } else {
     // Descend into this subtree.
-    let child = forward ? node.firstElementChild : node.lastElementChild
+    let child = getNextDescendantEl(node, forward)
     // Traverse siblings, searching the subtree of each one
     // for focusable elements.
     while (child) {
       const focusableEl = findFocusableElement(child as HTMLElement, forward)
       if (focusableEl) return focusableEl
-      child = forward ? child.nextElementSibling : child.previousElementSibling
+      child = getNextSiblingEl(child as HTMLElement, forward)
     }
   }
 
@@ -98,6 +96,14 @@ function findFocusableElement(
   if (!forward && isFocusable(node)) return node
 
   return null
+}
+
+function getNextDescendantEl(node: ParentNode, forward: boolean) {
+  return forward ? node.firstElementChild : node.lastElementChild
+}
+
+function getNextSiblingEl(el: HTMLElement, forward: boolean) {
+  return forward ? el.nextElementSibling : el.previousElementSibling
 }
 
 /**

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -53,15 +53,6 @@ function findFocusableElement(
     return null
   }
 
-  // If we're walking forward, descend starting at the first child;
-  // otherwise, start at the last child.
-  const descentPoint = forward ? 'firstElementChild' : 'lastElementChild'
-  // If we're walking forward, traverse siblings using nextElementSibling;
-  // otherwise, use previousElementSibling.
-  const siblingDirection = forward
-    ? 'nextElementSibling'
-    : 'previousElementSibling'
-
   // Start walking the DOM tree, looking for focusable elements.
   // If we find one, return it immediately.
 
@@ -69,13 +60,15 @@ function findFocusableElement(
   if (node.shadowRoot) {
     let shadowRoot = node.shadowRoot
     // Descend into this subtree.
-    let child = shadowRoot[descentPoint]
+    let child = forward
+      ? shadowRoot.firstElementChild
+      : shadowRoot.lastElementChild
     // Traverse siblings, searching the subtree of each one
     // for focusable elements.
     while (child) {
       const focusableEl = findFocusableElement(child as HTMLElement, forward)
       if (focusableEl) return focusableEl
-      child = child[siblingDirection]
+      child = forward ? child.nextElementSibling : child.previousElementSibling
     }
     // Case 2: If this node is a slot for a Custom Element,
     // search its assigned nodes recursively.
@@ -91,13 +84,13 @@ function findFocusableElement(
     // Case 3: this is a regular Light DOM node. Search its subtree.
   } else {
     // Descend into this subtree.
-    let child = node[descentPoint]
+    let child = forward ? node.firstElementChild : node.lastElementChild
     // Traverse siblings, searching the subtree of each one
     // for focusable elements.
     while (child) {
       const focusableEl = findFocusableElement(child as HTMLElement, forward)
       if (focusableEl) return focusableEl
-      child = child[siblingDirection]
+      child = forward ? child.nextElementSibling : child.previousElementSibling
     }
   }
 

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -1,22 +1,5 @@
 import focusableSelectors from 'focusable-selectors'
 
-// Elements with these ARIA roles make their children `presentational`, which
-// nullifies their semantics
-// @see: https://www.w3.org/TR/wai-aria/
-const PRESENTATIONAL_CHILDREN_SELECTOR = [
-  'a[href]',
-  'button',
-  'img',
-  'summary',
-  '[role="button"]',
-  '[role="image"]',
-  '[role="link"]',
-  '[role="math"]',
-  '[role="presentation"]',
-  '[role="progressbar"]',
-  '[role="scrollbar"]',
-  '[role="slider"]',
-].join(',')
 /**
  * Set the focus to the first element with `autofocus` with the element or the
  * element itself
@@ -117,6 +100,32 @@ export function isFocusable(el: HTMLElement) {
   )
 }
 
+// Elements with these ARIA roles make their children `presentational`, which
+// nullifies their semantics
+// @see: https://www.w3.org/TR/wai-aria/
+const PRESENTATIONAL_CHILDREN_SELECTOR = [
+  'a[href]',
+  'button',
+  'img',
+  'summary',
+  '[role="button"]',
+  '[role="image"]',
+  '[role="link"]',
+  '[role="math"]',
+  '[role="presentation"]',
+  '[role="progressbar"]',
+  '[role="scrollbar"]',
+  '[role="slider"]',
+].join(',')
+
+// Elemments matching these selectors are not available to the user.
+// Neither they nor any of their descentants can ever receive focus.
+const HIDDEN_FROM_USER_SELECTOR =
+  ':disabled,[aria-disabled="true"],[aria-hidden="true"],[hidden],[inert]'
+
+const cannotHaveFocusableChildrenSelector =
+  PRESENTATIONAL_CHILDREN_SELECTOR + ',' + HIDDEN_FROM_USER_SELECTOR
+
 /**
  * Determine if an element can have focusable children. Useful for bailing out
  * early when walking the DOM tree.
@@ -141,11 +150,7 @@ export function isFocusable(el: HTMLElement) {
  * ```
  */
 function canHaveFocusableChildren(el: HTMLElement) {
-  return !(
-    el.matches(
-      '[hidden],[inert],:disabled,[aria-hidden="true"],[aria-disabled="true"]'
-    ) && el.matches(PRESENTATIONAL_CHILDREN_SELECTOR)
-  )
+  return !el.matches(cannotHaveFocusableChildrenSelector)
 }
 
 // Get the active element, accounting for Shadow DOM subtrees.

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -16,9 +16,9 @@ export function getFocusableEdges(el: HTMLElement) {
   const first = findFocusableElement(el, true)
   let last = null
   // Only if we find the first element do we need to look for the last one.
-  // If there's no last element, element, we set `last` as a reference
+  // If there's no last element, we set `last` as a reference
   // to `first` so that the returned array is always of length 2.
-  if (first !== null) {
+  if (first) {
     last = findFocusableElement(el, false) || first
   }
   return [first, last] as const
@@ -34,8 +34,8 @@ function findFocusableElement(
     return node
   }
 
-  // If this node can't have focusable children, there's no point
-  // in walking its subtree.
+  // We should only search the subtree of this node
+  // if it can have focusable children.
   if (canHaveFocusableChildren(node)) {
     // Start walking the DOM tree, looking for focusable elements.
     // Case 1: If this node has a shadow root, search it recursively.

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -28,7 +28,7 @@ export function moveFocusToDialog(el: HTMLElement) {
 }
 
 // Get the first and last focusable elements in a given subtree
-export function getFirstAndLastFocusableChild(el: HTMLElement) {
+export function getFocusableEdges(el: HTMLElement) {
   const first = findFocusableElement(el, true)
   let last = null
   if (first !== null) {

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -10,14 +10,18 @@ export function moveFocusToDialog(el: HTMLElement) {
   focused.focus()
 }
 
-// Get the first and last focusable elements in a given subtree
+// Get the first and last focusable elements in a given tree.
 export function getFocusableEdges(el: HTMLElement) {
+  // Check for a focusable element within the subtree of `el`.
   const first = findFocusableElement(el, true)
   let last = null
+  // Only if we find the first element do we need to look for the last one.
+  // If there's no last element, element, we set `last` as a reference
+  // to `first` so that the returned array is always of length 2.
   if (first !== null) {
     last = findFocusableElement(el, false) || first
   }
-  return [first, last]
+  return [first, last] as const
 }
 
 function findFocusableElement(

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -128,8 +128,10 @@ export function getActiveElement(
 
   if (!activeEl) return null
 
-  // If there’s a shadow root, recursively look for the active element within it
-  if (activeEl.shadowRoot) return getActiveElement(activeEl.shadowRoot)
+  // If there’s a shadow root, recursively find the active element within it.
+  // If the recursive call returns null, return the active element of the top-level Document.
+  if (activeEl.shadowRoot)
+    return getActiveElement(activeEl.shadowRoot) || document.activeElement
 
   // If not, we can just return the active element
   return activeEl

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -80,9 +80,9 @@ function findFocusableElement(
     // Case 2: If this node is a slot for a Custom Element,
     // search its assigned nodes recursively.
   } else if (node.localName === 'slot') {
-    const assignedElements = [
-      ...(node as HTMLSlotElement).assignedElements({ flatten: true }),
-    ] as HTMLElement[]
+    const assignedElements = (node as HTMLSlotElement).assignedElements({
+      flatten: true,
+    }) as HTMLElement[]
     if (!forward) assignedElements.reverse()
     for (const assignedElement of assignedElements) {
       const focusableEl = findFocusableElement(assignedElement, forward)

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -119,7 +119,8 @@ const PRESENTATIONAL_CHILDREN_SELECTOR = [
   '[role="slider"]',
 ].join(',')
 
-// Elemments matching these selectors are not available to the user.
+// Elemments matching these selectors are either hidden entirely from the user,
+// or are visible but unavailable for interaction.
 // Neither they nor any of their descentants can ever receive focus.
 const HIDDEN_FROM_USER_SELECTOR =
   ':disabled,[aria-disabled="true"],[aria-hidden="true"],[hidden],[inert]'
@@ -140,9 +141,9 @@ const cannotHaveFocusableChildrenSelector =
  *   <a href="#">Link</a>
  * </div>
  * ```
- * This is bad HTML. Links render their children presentaional, so
- * the nested link has no meaning to the user. We bail out on the
- * parent link so we don't mistakenly think the nested link is focusable.
+ * This is bad HTML. Links make their children presentaional, so
+ * the nested link is not available to the user. We bail out on the
+ * parent link so we don't mistakenly consider the nested link focusable.
  * ```html
  * <a href="#">
  *   Hello,

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -79,9 +79,9 @@ function findFocusableElement(
     }
     // Case 2: If this node is a slot for a Custom Element,
     // search its assigned nodes recursively.
-  } else if (node instanceof HTMLSlotElement) {
+  } else if (node.localName === 'slot') {
     const assignedElements = [
-      ...node.assignedElements({ flatten: true }),
+      ...(node as HTMLSlotElement).assignedElements({ flatten: true }),
     ] as HTMLElement[]
     if (!forward) assignedElements.reverse()
     for (const assignedElement of assignedElements) {


### PR DESCRIPTION
## Table of contents
1. [Summary](#summary)
2. [How?](#how)
  i. [Examples](#examples)
3. [What is a `<slot>`?](#what-is-a-slot)
4. [Special thanks](#special-thanks)

## Summary
This PR makes it so that we only walk the tree of the dialog to find exactly the first and last focusable child of the dialog – no more collecting the whole array of focusable elements.

## How?
Two new functiions: 
- `findFocusableElement(node: HTMLElement, forward: boolean)`, which recursively walks the tree of the provided `node` until it finds a focusable element, then returns it. `findFoacusableElement()` can walk forward or backward, allowing us to search from the beginning or end of the dialog.
- `getFocusableEdges(node: HTMLElement)`, which calls `findFocusableElement()` twice – once to walk the DOM forward, and once to walk it backward. It returns an array of exactly two items: the first and last focusable child of the dialog.

### Examples

Consider the following DOM structure, simplified for readability:

```html
<div id="modal">
  <button id="close">Close</button>
  <p>I am some modal content <a href="#">with a link</a></p>
  <div id="button-group">
    <button id="cancel">Cancel</button>
    <button id="confirm">Confirm</button>
  </div>
</div>
```

When we want to find the focusable elements within `div#modal`, we call `getFocusableEdges()` on `div#modal`.

On the forward walk, we test if each node is focusable as we visit it. That looks like this:
1. `getFocusableEdges()` calls `findFocusableElement` on `div#modal`, and we walk the DOM forward.
2. `findFocusableElement()` is called on `div#modal`. It tests if `div#modal` is focusable. It is not focusable.
3. `findFocusableElement()` descends to the `firstElementChild` of `div#modal`.
4. `findFocusableElement()` is called on `button#close` and tests if `button#close` is focusable. It is focusable
5. `findFocusableElement()` returns `button#close`. `getFocusableEdges()` stores a reference to it.

`getFocusableEdges()` now calls `findFocusableElement()` to walk _backward_ to find the last focusable child in `div#modal`.

On the backward walk, we descend all the way into a node's tree before checking if the node itself is focusable. That looks like this:
1. `getFocusableEdges()` calls `findFocusableElement` on `div#modal`, and we walk the DOM backward.
2. `findFocusableElement()` descends to the `lastElementChild` of `div#modal`. This is `div#button-group`
3. `findFocusableElement()` descends to the `lastElementChild` of `div#button-group` This is `button#confirm`.
4. `button#confirm` has no children, so `findFocusableElement()` tests if `button#confirm` is focusable. It is.
5. `findFocusableElement()` returns `button#confirm`. `getFocusableEdges()` stores a reference to it

We're done walking the DOM, so `getFocusableEdges()` returns an array of exactly two items: `button#close` and `button#confirm`

## What is a `<slot>`?

Slots allow authors to define a place (a slot) for developer-supplied Light DOM content to be rendered inside a Web Component. Let's take this template for the `<fancy-card>` Web Component:

```html
<template id="fancy-card-template">
  <slot name="title">
    <!-- Developer-supplied Light DOM node goes here -->
  </slot>
  <slot name="content">
    <!-- Developer-supplied Light DOM node goes here -->
  </slot>
</template>
```

This template has two slots:
  1. `title`, for the title of the card
  2. `content`, for the card's main content. This can be a single node or a node with children.
  
The developer might use it like this.

```html
<fancy-card>
  <h2 slot="title">Why my cat is a weird little guy</h2>
  <div slot="content">
    <p>He sits like a man.</p>
  </div>
</fancy-card>
```

The `<h2>` will go inside the `title` slot, and the `<div>` (and its children) will go inside the `content` slot. These slotted children will be in the Light DOM, which is why we have to specifically look for them by calling `assignedElements()` on the slot.

## Special thanks
This algorithm wouldn't have been possible without the help and patience of @alice.