### PR TITLE
[Version 8] Test behavior of `getFocusableEdges()` to account for Shadow DOM trees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ cypress/screenshots
 .husky/_
 out
 dist/
-cypress/fixtures/a11y-dialog.js
+cypress/fixtures/*.js
 

--- a/cypress/e2e/getFocusableEdges.cy.js
+++ b/cypress/e2e/getFocusableEdges.cy.js
@@ -12,4 +12,23 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
       expect(focusableEdges[1]).to.not.be.null
     })
   })
+  it('Should return the same element twice if there is only one focusable element', () => {
+    cy.get('#light-dom-one-el').then(container => {
+      const focusableEdges = getFocusableEdges(container[0])
+
+      expect(focusableEdges).to.have.length(2)
+      expect(focusableEdges[0]).to.not.be.null
+      expect(focusableEdges[1]).to.not.be.null
+      expect(focusableEdges[0]).to.equal(focusableEdges[1])
+    })
+  })
+  it('Should return null if there are no focusable elements', () => {
+    cy.get('#light-dom-no-els').then(container => {
+      const focusableEdges = getFocusableEdges(container[0])
+
+      expect(focusableEdges).to.have.length(2)
+      expect(focusableEdges[0]).to.be.null
+      expect(focusableEdges[1]).to.be.null
+    })
+  })
 })

--- a/cypress/e2e/getFocusableEdges.cy.js
+++ b/cypress/e2e/getFocusableEdges.cy.js
@@ -14,49 +14,49 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
 
   it('should return [HTMLElement, HTMLElement] if focusable elements are present', () => {
     cy.get('#light-dom-two-els').then(container => {
-      const focusableEdges = getFocusableEdges(container[0])
+      const elems = getFocusableEdges(container[0])
 
-      expect(focusableEdges).to.have.length(2)
-      expect(focusableEdges[0]).to.not.be.null
-      expect(focusableEdges[1]).to.not.be.null
+      expect(elems).to.have.length(2)
+      expect(elems[0]).to.not.be.null
+      expect(elems[1]).to.not.be.null
     })
   })
   it('should return the same element twice if there is only one focusable element', () => {
     cy.get('#light-dom-one-el').then(container => {
-      const focusableEdges = getFocusableEdges(container[0])
+      const elems = getFocusableEdges(container[0])
 
-      expect(focusableEdges).to.have.length(2)
-      expect(focusableEdges[0]).to.not.be.null
-      expect(focusableEdges[1]).to.not.be.null
-      expect(focusableEdges[0]).to.equal(focusableEdges[1])
+      expect(elems).to.have.length(2)
+      expect(elems[0]).to.not.be.null
+      expect(elems[1]).to.not.be.null
+      expect(elems[0]).to.equal(elems[1])
     })
   })
   it('should return [null, null] if there are no focusable elements', () => {
     cy.get('#light-dom-no-els').then(container => {
-      const focusableEdges = getFocusableEdges(container[0])
+      const elems = getFocusableEdges(container[0])
 
-      expect(focusableEdges).to.have.length(2)
-      expect(focusableEdges[0]).to.be.null
-      expect(focusableEdges[1]).to.be.null
+      expect(elems).to.have.length(2)
+      expect(elems[0]).to.be.null
+      expect(elems[1]).to.be.null
     })
   })
   it('should return Shadow DOM elements', () => {
     cy.get('#shadow-dom-two-els').then(container => {
-      const focusableEdges = getFocusableEdges(container[0])
+      const elems = getFocusableEdges(container[0])
 
-      expect(focusableEdges).to.have.length(2)
-      expect(focusableEdges[0]).to.not.be.null
-      expect(focusableEdges[1]).to.not.be.null
-      expect(isInShadow(focusableEdges[0])).to.be.true
+      expect(elems).to.have.length(2)
+      expect(elems[0]).to.not.be.null
+      expect(elems[1]).to.not.be.null
+      expect(isInShadow(elems[0])).to.be.true
     })
   })
   it('should return slotted Light DOM elements and elements nested in Shadow DOM', () => {
     cy.get('#shadow-dom-mixed').then(container => {
-      const focusableEdges = getFocusableEdges(container[0])
+      const elems = getFocusableEdges(container[0])
 
-      expect(focusableEdges).to.have.length(2)
+      expect(elems).to.have.length(2)
 
-      const [first, last] = focusableEdges
+      const [first, last] = elems
 
       expect(first).to.not.be.null
       expect(last).to.not.be.null
@@ -70,30 +70,30 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
   })
   it('should return focusable Shadow DOM hosts', () => {
     cy.get('#focusable-shadow-host').then(container => {
-      const focusableEdges = getFocusableEdges(container[0])
+      const elems = getFocusableEdges(container[0])
 
-      expect(focusableEdges).to.have.length(2)
-      expect(focusableEdges[0]).to.not.be.null
-      expect(focusableEdges[1]).to.not.be.null
+      expect(elems).to.have.length(2)
+      expect(elems[0]).to.not.be.null
+      expect(elems[1]).to.not.be.null
     })
   })
   it('should ignore nodes in unfocusable subtrees', () => {
     cy.get('#inert-children').then(container => {
-      const focusableEdges = getFocusableEdges(container[0])
+      const elems = getFocusableEdges(container[0])
 
-      expect(focusableEdges).to.have.length(2)
+      expect(elems).to.have.length(2)
       // The child of the inert div
-      expect(focusableEdges[0]).to.be.null
+      expect(elems[0]).to.be.null
       // The individially disabled button
-      expect(focusableEdges[1]).to.be.null
+      expect(elems[1]).to.be.null
     })
     cy.get('#hidden-children').then(container => {
-      const focusableEdges = getFocusableEdges(container[0])
+      const elems = getFocusableEdges(container[0])
 
       // The only focusable element is the child of a hidden div
-      expect(focusableEdges).to.have.length(2)
-      expect(focusableEdges[0]).to.be.null
-      expect(focusableEdges[1]).to.be.null
+      expect(elems).to.have.length(2)
+      expect(elems[0]).to.be.null
+      expect(elems[1]).to.be.null
     })
   })
 })

--- a/cypress/e2e/getFocusableEdges.cy.js
+++ b/cypress/e2e/getFocusableEdges.cy.js
@@ -58,4 +58,23 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
       expect(focusableEdges[1]).to.not.be.null
     })
   })
+  it('should ignore nodes in unfocusable subtrees', () => {
+    cy.get('#inert-children').then(container => {
+      const focusableEdges = getFocusableEdges(container[0])
+
+      expect(focusableEdges).to.have.length(2)
+      // The child of the inert div
+      expect(focusableEdges[0]).to.be.null
+      // The individially disabled button
+      expect(focusableEdges[1]).to.be.null
+    })
+    cy.get('#hidden-children').then(container => {
+      const focusableEdges = getFocusableEdges(container[0])
+
+      // The only focusable element is the child of a hidden div
+      expect(focusableEdges).to.have.length(2)
+      expect(focusableEdges[0]).to.be.null
+      expect(focusableEdges[1]).to.be.null
+    })
+  })
 })

--- a/cypress/e2e/getFocusableEdges.cy.js
+++ b/cypress/e2e/getFocusableEdges.cy.js
@@ -40,4 +40,13 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
       expect(focusableEdges[1]).to.not.be.null
     })
   })
+  it('should return elements nested in Shadow DOM subtrees', () => {
+    cy.get('#shadow-dom-nested').then(container => {
+      const focusableEdges = getFocusableEdges(container[0])
+
+      expect(focusableEdges).to.have.length(2)
+      expect(focusableEdges[0]).to.not.be.null
+      expect(focusableEdges[1]).to.not.be.null
+    })
+  })
 })

--- a/cypress/e2e/getFocusableEdges.cy.js
+++ b/cypress/e2e/getFocusableEdges.cy.js
@@ -1,5 +1,14 @@
 import { getFocusableEdges } from '../fixtures/dom-utils'
 
+// Helper function to check if an element is in a Shadow DOM
+function isInShadow(node) {
+  while (node) {
+    if (node.toString() === '[object ShadowRoot]') return true
+    node = node.parentNode
+  }
+  return false
+}
+
 describe('getFocusableEdges()', { testIsolation: false }, () => {
   before(() => cy.visit('/get-focusable-edges'))
 
@@ -38,7 +47,7 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
       expect(focusableEdges).to.have.length(2)
       expect(focusableEdges[0]).to.not.be.null
       expect(focusableEdges[1]).to.not.be.null
-      expect(focusableEdges[0].host).to.not.be.null
+      expect(isInShadow(focusableEdges[0])).to.be.true
     })
   })
   it('should return slotted Light DOM elements and elements nested in Shadow DOM', () => {
@@ -53,10 +62,10 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
       expect(last).to.not.be.null
 
       // The first focusable element is slotted, so it has no host
-      expect(first.host instanceof ShadowRoot).to.be.false
+      expect(isInShadow(first)).to.be.false
       expect(first.id).to.equal('slotted-link')
       // The last focusable element is nested in a Shadow DOM
-      expect(last.host).to.not.be.null
+      expect(isInShadow(last)).to.be.true
     })
   })
   it('should return focusable Shadow DOM hosts', () => {

--- a/cypress/e2e/getFocusableEdges.cy.js
+++ b/cypress/e2e/getFocusableEdges.cy.js
@@ -49,4 +49,13 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
       expect(focusableEdges[1]).to.not.be.null
     })
   })
+  it('should return focusable Shadow DOM hosts', () => {
+    cy.get('#focusable-shadow-host').then(container => {
+      const focusableEdges = getFocusableEdges(container[0])
+
+      expect(focusableEdges).to.have.length(2)
+      expect(focusableEdges[0]).to.not.be.null
+      expect(focusableEdges[1]).to.not.be.null
+    })
+  })
 })

--- a/cypress/e2e/getFocusableEdges.cy.js
+++ b/cypress/e2e/getFocusableEdges.cy.js
@@ -8,17 +8,25 @@ function isInShadow(node) {
   }
   return false
 }
+// Cypress runs everything in its own iframes, so we can't assert
+// .instanceOf(Element) here; we have to use its helper function.
+const isElement = Cypress.dom.isElement
 
 describe('getFocusableEdges()', { testIsolation: false }, () => {
   before(() => cy.visit('/get-focusable-edges'))
 
-  it('should return [HTMLElement, HTMLElement] if focusable elements are present', () => {
+  it('should return two unique elements if multiple focusable elements are present', () => {
     cy.get('#light-dom-two-els').then(container => {
       const elems = getFocusableEdges(container[0])
-
       expect(elems).to.have.length(2)
-      expect(elems[0]).to.not.be.null
-      expect(elems[1]).to.not.be.null
+
+      const [first, last] = elems
+
+      expect(isElement(first)).to.be.true
+      expect(isElement(last)).to.be.true
+      expect(first).to.not.equal(last)
+      expect(first).to.have.property('id', 'first')
+      expect(last).to.have.property('id', 'last')
     })
   })
   it('should return the same element twice if there is only one focusable element', () => {

--- a/cypress/e2e/getFocusableEdges.cy.js
+++ b/cypress/e2e/getFocusableEdges.cy.js
@@ -21,10 +21,9 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
   it('should return two unique elements if multiple focusable elements are present', () => {
     cy.get('#light-dom-two-els').then(container => {
       const elems = getFocusableEdges(container[0])
-      expect(elems).to.have.length(2)
-
       const [first, last] = elems
 
+      expect(elems).to.have.length(2)
       expect(isElement(first)).to.be.true
       expect(isElement(last)).to.be.true
       expect(first).to.not.equal(last)
@@ -35,20 +34,22 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
   it('should return the same element twice if there is only one focusable element', () => {
     cy.get('#light-dom-one-el').then(container => {
       const elems = getFocusableEdges(container[0])
+      const [first, last] = elems
 
       expect(elems).to.have.length(2)
-      expect(elems[0]).to.not.be.null
-      expect(elems[1]).to.not.be.null
-      expect(elems[0]).to.equal(elems[1])
+      expect(first).to.not.be.null
+      expect(last).to.not.be.null
+      expect(first).to.equal(last)
     })
   })
   it('should return [null, null] if there are no focusable elements', () => {
     cy.get('#light-dom-no-els').then(container => {
       const elems = getFocusableEdges(container[0])
+      const [first, last] = elems
 
       expect(elems).to.have.length(2)
-      expect(elems[0]).to.be.null
-      expect(elems[1]).to.be.null
+      expect(first).to.be.null
+      expect(last).to.be.null
     })
   })
   it('should return Shadow DOM elements', () => {
@@ -66,14 +67,11 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
   it('should return slotted Light DOM elements and elements nested in Shadow DOM', () => {
     cy.get('#shadow-dom-mixed').then(container => {
       const elems = getFocusableEdges(container[0])
-
-      expect(elems).to.have.length(2)
-
       const [first, last] = elems
 
+      expect(elems).to.have.length(2)
       expect(first).to.not.be.null
       expect(last).to.not.be.null
-
       // The first focusable element is slotted, so it has no host
       expect(isInShadow(first)).to.be.false
       expect(first.id).to.equal('slotted-link')
@@ -96,20 +94,22 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
   it('should ignore nodes in unfocusable subtrees', () => {
     cy.get('#inert-children').then(container => {
       const elems = getFocusableEdges(container[0])
+      const [first, last] = elems
 
       expect(elems).to.have.length(2)
       // The child of the inert div
-      expect(elems[0]).to.be.null
+      expect(first).to.be.null
       // The individially disabled button
-      expect(elems[1]).to.be.null
+      expect(last).to.be.null
     })
     cy.get('#hidden-children').then(container => {
       const elems = getFocusableEdges(container[0])
+      const [first, last] = elems
 
       // The only focusable element is the child of a hidden div
       expect(elems).to.have.length(2)
-      expect(elems[0]).to.be.null
-      expect(elems[1]).to.be.null
+      expect(first).to.be.null
+      expect(last).to.be.null
     })
   })
 })

--- a/cypress/e2e/getFocusableEdges.cy.js
+++ b/cypress/e2e/getFocusableEdges.cy.js
@@ -191,4 +191,22 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
       expect(last).to.be.null
     })
   })
+
+  /**
+   * Browsers hide all non-<summary> descendants of closed <details> elements
+   * from user interaction, but those non-<summary> elements may still match our
+   * focusable-selectors and may still have dimensions, so we need a special
+   * case to ignore them.
+   */
+  // TODO: This test is currently failing. We do not match this browser
+  // behavior yet.
+  it.skip('should should ignore non-<summary> elements in a closed <details>', () => {
+    cy.get('#with-details').then(container => {
+      const [first, last] = getFocusableEdges(container[0])
+      expect(isElement(first)).to.be.true
+      expect(first.localName).to.equal('summary')
+      // This is the only focusable element, so it should be returned twice
+      expect(first).to.equal(last)
+    })
+  })
 })

--- a/cypress/e2e/getFocusableEdges.cy.js
+++ b/cypress/e2e/getFocusableEdges.cy.js
@@ -1,0 +1,15 @@
+import { getFocusableEdges } from '../fixtures/dom-utils'
+
+describe('getFocusableEdges()', { testIsolation: false }, () => {
+  before(() => cy.visit('/get-focusable-edges'))
+
+  it('should return an array of focusable elements', () => {
+    cy.get('#light-dom-two-els').then(container => {
+      const focusableEdges = getFocusableEdges(container[0])
+
+      expect(focusableEdges).to.have.length(2)
+      expect(focusableEdges[0]).to.not.be.null
+      expect(focusableEdges[1]).to.not.be.null
+    })
+  })
+})

--- a/cypress/e2e/getFocusableEdges.cy.js
+++ b/cypress/e2e/getFocusableEdges.cy.js
@@ -141,4 +141,39 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
       expect(last).to.be.null
     })
   })
+
+  /**
+   * A shadow host that delegates focus will never directly receive focus,
+   * even when the host itself is focusable. Consider our <fancy-button> custom
+   * element, which delegates focus. If we were to apply a tabindex to it, it
+   * would look like this:
+   *
+   * <fancy-button tabindex="0">
+   *  #shadow-root
+   *  <button><slot></slot></button>
+   * </fancy-button>
+   *
+   * The browser acts as as if there is only one focusable element – the shadow
+   * button. Our library should behave the same way.
+   */
+  // TODO: This test is currently failing. We do not account for this
+  // browser behavior.
+  it.skip('should ignore focusable shadow hosts if they delegate focus to their shadow subtree', () => {
+    cy.get('#shadow-host-delegates-focus').then(container => {
+      // Get the shadow host element in this container
+      const focusableShadowHostEl = container.find(
+        '[data-cy-delegates-focus]'
+      )[0]
+      // Get the first focusable element, according to our library
+      const [first] = getFocusableEdges(container[0])
+
+      // Assert that we have a shadow host that delegates focus to its subtree
+      expect(focusableShadowHostEl.shadowRoot?.delegatesFocus).to.be.true
+      // Assert that the host el is *not* what our library returns
+      expect(first).to.not.equal(focusableShadowHostEl)
+      // Assert that our library returns the button inside the shadow subtree
+      expect(isInShadow(first)).to.be.true
+      expect(first).to.have.prop('localName', 'button')
+    })
+  })
 })

--- a/cypress/e2e/getFocusableEdges.cy.js
+++ b/cypress/e2e/getFocusableEdges.cy.js
@@ -11,9 +11,7 @@ function isInShadow(node) {
 
 const hasShadowDOM = node => !!node.shadowRoot
 
-// Cypress runs everything in its own iframes, so we can't assert
-// .instanceOf(Element) here; we have to use its helper function.
-const isElement = Cypress.dom.isElement
+const { isElement, isFocusable, isHidden } = Cypress.dom
 
 describe('getFocusableEdges()', { testIsolation: false }, () => {
   before(() => cy.visit('/get-focusable-edges'))
@@ -96,6 +94,11 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
       const elems = getFocusableEdges(container[0])
       const [first, last] = elems
 
+      const inertNode = container.find('div[inert]')
+      const disabledNode = container.find('button[disabled]')
+      expect(isFocusable(inertNode)).to.be.false
+      expect(isFocusable(disabledNode)).to.be.false
+
       expect(elems).to.have.length(2)
       // The child of the inert div
       expect(first).to.be.null
@@ -105,7 +108,10 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
     cy.get('#hidden-children').then(container => {
       const elems = getFocusableEdges(container[0])
       const [first, last] = elems
+      const hiddenNode = container.find('div[hidden]')
 
+      expect(isHidden(hiddenNode)).to.be.true
+      expect(isFocusable(hiddenNode)).to.be.false
       // The only focusable element is the child of a hidden div
       expect(elems).to.have.length(2)
       expect(first).to.be.null

--- a/cypress/e2e/getFocusableEdges.cy.js
+++ b/cypress/e2e/getFocusableEdges.cy.js
@@ -31,4 +31,13 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
       expect(focusableEdges[1]).to.be.null
     })
   })
+  it('Should return Shadow DOM elements', () => {
+    cy.get('#shadow-dom-two-els').then(container => {
+      const focusableEdges = getFocusableEdges(container[0])
+
+      expect(focusableEdges).to.have.length(2)
+      expect(focusableEdges[0]).to.not.be.null
+      expect(focusableEdges[1]).to.not.be.null
+    })
+  })
 })

--- a/cypress/e2e/getFocusableEdges.cy.js
+++ b/cypress/e2e/getFocusableEdges.cy.js
@@ -156,8 +156,8 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
    * The browser acts as as if there is only one focusable element – the shadow
    * button. Our library should behave the same way.
    */
-  // TODO: This test is currently failing. We do not account for this
-  // browser behavior.
+  // TODO: This test is currently failing. We do not match this
+  // browser behavior yet
   it.skip('should ignore focusable shadow hosts if they delegate focus to their shadow subtree', () => {
     cy.get('#shadow-host-delegates-focus').then(container => {
       // Get the shadow host element in this container
@@ -174,6 +174,29 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
       // Assert that our library returns the button inside the shadow subtree
       expect(isInShadow(first)).to.be.true
       expect(first).to.have.prop('localName', 'button')
+    })
+  })
+  /**
+   * The browser will never send focus into a Shadow DOM if the host element
+   * has a negative tabindex. This applies to both slotted Light DOM Shadow DOM
+   * children
+   */
+  // TODO: This test is currently failing. We do not match this browser behavior yet.
+  it.skip('should ignore shadow hosts with a negative tabindex', () => {
+    cy.get('#shadow-host-negative-tabindex').then(container => {
+      // Get the <fancy-card> with a negative tabindex
+      const shadowHostEl = container.find('[data-cy-negative-tabindex]')[0]
+      // Get the first and last focusable element, according to our library
+      const [first, last] = getFocusableEdges(container[0])
+
+      // Assert that the shadow host has a negative tabindex
+      expect(shadowHostEl).to.have.attr('tabindex', '-1')
+      // Asseert that the shadow DOM contains a <fancy-button>
+      expect(shadowHostEl.shadowRoot?.querySelector('fancy-button')).to.not.be
+        .null
+      // Assert that our library finds no focusable elements in this container
+      expect(first).to.be.null
+      expect(last).to.be.null
     })
   })
 })

--- a/cypress/e2e/getFocusableEdges.cy.js
+++ b/cypress/e2e/getFocusableEdges.cy.js
@@ -41,13 +41,22 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
       expect(focusableEdges[0].host).to.not.be.null
     })
   })
-  it('should return elements nested in Shadow DOM subtrees', () => {
-    cy.get('#shadow-dom-nested').then(container => {
+  it('should return slotted Light DOM elements and elements nested in Shadow DOM', () => {
+    cy.get('#shadow-dom-mixed').then(container => {
       const focusableEdges = getFocusableEdges(container[0])
 
       expect(focusableEdges).to.have.length(2)
-      expect(focusableEdges[0]).to.not.be.null
-      expect(focusableEdges[1]).to.not.be.null
+
+      const [first, last] = focusableEdges
+
+      expect(first).to.not.be.null
+      expect(last).to.not.be.null
+
+      // The first focusable element is slotted, so it has no host
+      expect(first.host instanceof ShadowRoot).to.be.false
+      expect(first.id).to.equal('slotted-link')
+      // The last focusable element is nested in a Shadow DOM
+      expect(last.host).to.not.be.null
     })
   })
   it('should return focusable Shadow DOM hosts', () => {

--- a/cypress/e2e/getFocusableEdges.cy.js
+++ b/cypress/e2e/getFocusableEdges.cy.js
@@ -8,6 +8,9 @@ function isInShadow(node) {
   }
   return false
 }
+
+const hasShadowDOM = node => !!node.shadowRoot
+
 // Cypress runs everything in its own iframes, so we can't assert
 // .instanceOf(Element) here; we have to use its helper function.
 const isElement = Cypress.dom.isElement
@@ -51,11 +54,13 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
   it('should return Shadow DOM elements', () => {
     cy.get('#shadow-dom-two-els').then(container => {
       const elems = getFocusableEdges(container[0])
+      const [first, last] = elems
 
       expect(elems).to.have.length(2)
-      expect(elems[0]).to.not.be.null
-      expect(elems[1]).to.not.be.null
-      expect(isInShadow(elems[0])).to.be.true
+      expect(first).to.not.be.null
+      expect(last).to.not.be.null
+      expect(isInShadow(first)).to.be.true
+      expect(isInShadow(last)).to.be.true
     })
   })
   it('should return slotted Light DOM elements and elements nested in Shadow DOM', () => {
@@ -79,10 +84,13 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
   it('should return focusable Shadow DOM hosts', () => {
     cy.get('#focusable-shadow-host').then(container => {
       const elems = getFocusableEdges(container[0])
+      const [first, last] = elems
 
       expect(elems).to.have.length(2)
-      expect(elems[0]).to.not.be.null
-      expect(elems[1]).to.not.be.null
+      expect(first).to.not.be.null
+      expect(last).to.not.be.null
+      expect(hasShadowDOM(first)).to.be.true
+      expect(hasShadowDOM(last)).to.be.true
     })
   })
   it('should ignore nodes in unfocusable subtrees', () => {

--- a/cypress/e2e/getFocusableEdges.cy.js
+++ b/cypress/e2e/getFocusableEdges.cy.js
@@ -3,7 +3,7 @@ import { getFocusableEdges } from '../fixtures/dom-utils'
 describe('getFocusableEdges()', { testIsolation: false }, () => {
   before(() => cy.visit('/get-focusable-edges'))
 
-  it('should return an array of focusable elements', () => {
+  it('should return [HTMLElement, HTMLElement] if focusable elements are present', () => {
     cy.get('#light-dom-two-els').then(container => {
       const focusableEdges = getFocusableEdges(container[0])
 
@@ -38,6 +38,7 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
       expect(focusableEdges).to.have.length(2)
       expect(focusableEdges[0]).to.not.be.null
       expect(focusableEdges[1]).to.not.be.null
+      expect(focusableEdges[0].host).to.not.be.null
     })
   })
   it('should return elements nested in Shadow DOM subtrees', () => {

--- a/cypress/e2e/getFocusableEdges.cy.js
+++ b/cypress/e2e/getFocusableEdges.cy.js
@@ -57,9 +57,7 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
       const elems = getFocusableEdges(container[0])
       const [first, last] = elems
 
-      expect(elems).to.have.length(2)
-      expect(first).to.not.be.null
-      expect(last).to.not.be.null
+      expect(isElement(first)).to.be.true
       expect(first).to.equal(last)
     })
   })
@@ -75,12 +73,10 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
   })
   it('should return Shadow DOM elements', () => {
     cy.get('#shadow-dom-two-els').then(container => {
-      const elems = getFocusableEdges(container[0])
-      const [first, last] = elems
+      const [first, last] = getFocusableEdges(container[0])
 
-      expect(elems).to.have.length(2)
-      expect(first).to.not.be.null
-      expect(last).to.not.be.null
+      expect(isElement(first)).to.be.true
+      expect(isElement(last)).to.be.true
       expect(isInShadow(first)).to.be.true
       expect(isInShadow(last)).to.be.true
     })
@@ -90,9 +86,6 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
       const elems = getFocusableEdges(container[0])
       const [first, last] = elems
 
-      expect(elems).to.have.length(2)
-      expect(first).to.not.be.null
-      expect(last).to.not.be.null
       // The first focusable element is slotted, so it has no host
       expect(isInShadow(first)).to.be.false
       expect(first.id).to.equal('slotted-link')
@@ -105,9 +98,8 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
       const elems = getFocusableEdges(container[0])
       const [first, last] = elems
 
-      expect(elems).to.have.length(2)
-      expect(first).to.not.be.null
-      expect(last).to.not.be.null
+      expect(isElement(first)).to.be.true
+      expect(isElement(last)).to.be.true
       expect(hasShadowDOM(first)).to.be.true
       expect(hasShadowDOM(last)).to.be.true
     })

--- a/cypress/e2e/getFocusableEdges.cy.js
+++ b/cypress/e2e/getFocusableEdges.cy.js
@@ -2,22 +2,21 @@ import { getFocusableEdges } from '../fixtures/dom-utils'
 const { isElement, isFocusable: _isFocusable, isHidden } = Cypress.dom
 
 // The types of Cypress.dom.isFocusable are wrong >:C
-// Elements must be jQuery objects.
+// It only accepts jQuery objects.
 const isFocusable = element =>
   element instanceof Cypress.$
     ? _isFocusable(element)
     : _isFocusable(Cypress.$(element))
 
-// Helper function to check if an element is in a Shadow DOM
-function isInShadow(node) {
-  while (node) {
-    if (node.toString() === '[object ShadowRoot]') return true
-    node = node.parentNode
+const isInShadow = element => {
+  while (element) {
+    if (element.toString() === '[object ShadowRoot]') return true
+    element = element.parentNode
   }
   return false
 }
 
-const hasShadowDOM = node => !!node.shadowRoot
+const hasShadowDOM = element => !!element.shadowRoot
 
 describe('getFocusableEdges()', { testIsolation: false }, () => {
   before(() => cy.visit('/get-focusable-edges'))

--- a/cypress/e2e/getFocusableEdges.cy.js
+++ b/cypress/e2e/getFocusableEdges.cy.js
@@ -12,7 +12,7 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
       expect(focusableEdges[1]).to.not.be.null
     })
   })
-  it('Should return the same element twice if there is only one focusable element', () => {
+  it('should return the same element twice if there is only one focusable element', () => {
     cy.get('#light-dom-one-el').then(container => {
       const focusableEdges = getFocusableEdges(container[0])
 
@@ -22,7 +22,7 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
       expect(focusableEdges[0]).to.equal(focusableEdges[1])
     })
   })
-  it('Should return null if there are no focusable elements', () => {
+  it('should return [null, null] if there are no focusable elements', () => {
     cy.get('#light-dom-no-els').then(container => {
       const focusableEdges = getFocusableEdges(container[0])
 
@@ -31,7 +31,7 @@ describe('getFocusableEdges()', { testIsolation: false }, () => {
       expect(focusableEdges[1]).to.be.null
     })
   })
-  it('Should return Shadow DOM elements', () => {
+  it('should return Shadow DOM elements', () => {
     cy.get('#shadow-dom-two-els').then(container => {
       const focusableEdges = getFocusableEdges(container[0])
 

--- a/cypress/fixtures/get-focusable-edges.html
+++ b/cypress/fixtures/get-focusable-edges.html
@@ -40,7 +40,7 @@
       </div>
       <div id="focusable-shadow-host">
         <h2>Node with a focusable Shadow DOM host</h2>
-        <fancy-div tabindex="1">I'm a focusable Shadow DOM host!</fancy-div>
+        <fancy-div tabindex="0">I'm a focusable Shadow DOM host!</fancy-div>
       </div>
       <div id="inert-children">
         <h2>Node with inert children</h2>

--- a/cypress/fixtures/get-focusable-edges.html
+++ b/cypress/fixtures/get-focusable-edges.html
@@ -33,9 +33,14 @@
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed
             euismod, nisl nec ultricies ultricies, nunc nisl aliquam nisl, eget
-            aliquam nisl nunc vel nisl. <a href="#">Sed</a> euismod, nisl nec ultricies.
+            aliquam nisl nunc vel nisl. <a href="#">Sed</a> euismod, nisl nec
+            ultricies.
           </p>
         </fancy-card>
+      </div>
+      <div id="focusable-shadow-host">
+        <h2>Node with a focusable Shadow DOM host</h2>
+        <fancy-div tabindex="1">I'm a focusable Shadow DOM host!</fancy-div>
       </div>
     </main>
     <script>

--- a/cypress/fixtures/get-focusable-edges.html
+++ b/cypress/fixtures/get-focusable-edges.html
@@ -26,6 +26,17 @@
         <fancy-button id="start">Start</fancy-button>
         <fancy-button id="end">End</fancy-button>
       </div>
+      <div id="shadow-dom-nested">
+        <h2>Node with one focusable Shadow DOM element child</h2>
+        <fancy-card>
+          <h2>Hellaur</h2>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed
+            euismod, nisl nec ultricies ultricies, nunc nisl aliquam nisl, eget
+            aliquam nisl nunc vel nisl. <a href="#">Sed</a> euismod, nisl nec ultricies.
+          </p>
+        </fancy-card>
+      </div>
     </main>
     <script>
       window.customElements.define(

--- a/cypress/fixtures/get-focusable-edges.html
+++ b/cypress/fixtures/get-focusable-edges.html
@@ -21,6 +21,11 @@
       <div id="light-dom-no-els">
         <h2>Node with no focusable element children</h2>
       </div>
+      <div id="shadow-dom-two-els">
+        <h2>Node with two focusable Shadow DOM element children</h2>
+        <fancy-button id="start">Start</fancy-button>
+        <fancy-button id="end">End</fancy-button>
+      </div>
     </main>
     <script>
       window.customElements.define(

--- a/cypress/fixtures/get-focusable-edges.html
+++ b/cypress/fixtures/get-focusable-edges.html
@@ -14,6 +14,13 @@
         <button id="first">Start</button>
         <a href="#" id="last">End</a>
       </div>
+      <div id="light-dom-multiple-els">
+        <h2>Node with multiple focusable element children</h2>
+        <button data-cy="first" data-cy-focus-candidate>First</button>
+        <button data-cy="second" data-cy-focus-candidate>Second</button>
+        <button data-cy="third" data-cy-focus-candidate>Third</button>
+        <button data-cy="fourth" data-cy-focus-candidate>Fourth</button>
+      </div>
       <div id="light-dom-one-el">
         <h2>Node with one focusable Light DOM element child</h2>
         <button id="solo">Start</button>
@@ -33,8 +40,8 @@
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed
             euismod, nisl nec ultricies ultricies, nunc nisl aliquam nisl, eget
-            aliquam nisl nunc vel nisl. <a href="#" id="slotted-link">Sed</a> euismod, nisl nec
-            ultricies.
+            aliquam nisl nunc vel nisl.
+            <a href="#" id="slotted-link">Sed</a> euismod, nisl nec ultricies.
           </p>
         </fancy-card>
       </div>

--- a/cypress/fixtures/get-focusable-edges.html
+++ b/cypress/fixtures/get-focusable-edges.html
@@ -62,6 +62,23 @@
           <button class="link-like">Hellaur</button>
         </div>
       </div>
+      <div id="shadow-host-delegates-focus">
+        <p>Custom Elements that delegate focus</p>
+        should <i>not</i> return the host as a focusable element; only the
+        focusable elements in the shadow DOM.
+        <fancy-button data-cy-delegates-focus tabindex="0">I'm in the Shadow DOM</fancy-button
+        >
+      </div>
+      <div id="shadow-host-negative-tabindex">
+        <p>
+          Custom Elements with a tabindex of -1 render their children
+          unfocusable.
+        </p>
+        <fancy-card tabindex="-1">
+          <h3>AAAA</h3>
+          <p>Hello, <a href="#">link</a></p>
+        </fancy-card>
+      </div>
     </main>
     <script>
       window.customElements.define(

--- a/cypress/fixtures/get-focusable-edges.html
+++ b/cypress/fixtures/get-focusable-edges.html
@@ -26,14 +26,14 @@
         <fancy-button id="start">Start</fancy-button>
         <fancy-button id="end">End</fancy-button>
       </div>
-      <div id="shadow-dom-nested">
-        <h2>Node with one focusable Shadow DOM element child</h2>
+      <div id="shadow-dom-mixed">
+        <h2>Node with Shadow DOM and slotted element children</h2>
         <fancy-card>
           <h2>Hellaur</h2>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed
             euismod, nisl nec ultricies ultricies, nunc nisl aliquam nisl, eget
-            aliquam nisl nunc vel nisl. <a href="#">Sed</a> euismod, nisl nec
+            aliquam nisl nunc vel nisl. <a href="#" id="slotted-link">Sed</a> euismod, nisl nec
             ultricies.
           </p>
         </fancy-card>

--- a/cypress/fixtures/get-focusable-edges.html
+++ b/cypress/fixtures/get-focusable-edges.html
@@ -74,7 +74,7 @@
           Custom Elements with a tabindex of -1 render their children
           unfocusable.
         </p>
-        <fancy-card tabindex="-1">
+        <fancy-card tabindex="-1" data-cy-negative-tabindex>
           <h3>AAAA</h3>
           <p>Hello, <a href="#">link</a></p>
         </fancy-card>

--- a/cypress/fixtures/get-focusable-edges.html
+++ b/cypress/fixtures/get-focusable-edges.html
@@ -1,26 +1,27 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Tests — Base</title>
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
 
-<head>
-  <meta charset="utf-8">
-  <title>Tests — Base</title>
-  <link rel="stylesheet" href="../styles.css" />
-</head>
-
-<body>
-  <main>
-    <h1>Tests — <code>getFocusableEdges()</code></h1>
-    <div id="light-dom-two-els">
-      <h2>Node with two focusable Light DOM element children</h2>
-      <button id="start">Start</button>
-      <a href="#">End</a>
-    </div>
-    <div id="light-dom-one-el">
-      <h2>Node with one focusable Light DOM element child</h2>
-      <button id="start">Start</button>
-    </div>
-    <div id="light-dom-no-els">
-      <h2>Node with no focusable element children</h2>
+  <body>
+    <main>
+      <h1>Tests — <code>getFocusableEdges()</code></h1>
+      <div id="light-dom-two-els">
+        <h2>Node with two focusable Light DOM element children</h2>
+        <button id="start">Start</button>
+        <a href="#">End</a>
+      </div>
+      <div id="light-dom-one-el">
+        <h2>Node with one focusable Light DOM element child</h2>
+        <button id="start">Start</button>
+      </div>
+      <div id="light-dom-no-els">
+        <h2>Node with no focusable element children</h2>
+      </div>
+    </main>
     <script>
       window.customElements.define(
         'fancy-button',
@@ -101,6 +102,5 @@
         }
       )
     </script>
-</body>
-
+  </body>
 </html>

--- a/cypress/fixtures/get-focusable-edges.html
+++ b/cypress/fixtures/get-focusable-edges.html
@@ -42,6 +42,19 @@
         <h2>Node with a focusable Shadow DOM host</h2>
         <fancy-div tabindex="1">I'm a focusable Shadow DOM host!</fancy-div>
       </div>
+      <div id="inert-children">
+        <h2>Node with inert children</h2>
+        <div inert>
+          <button class="link-like">Hellaur</button>
+        </div>
+        <button disabled>Goodbye</button>
+      </div>
+      <div id="hidden-children">
+        <h2>Node with hidden children 2</h2>
+        <div hidden>
+          <button class="link-like">Hellaur</button>
+        </div>
+      </div>
     </main>
     <script>
       window.customElements.define(

--- a/cypress/fixtures/get-focusable-edges.html
+++ b/cypress/fixtures/get-focusable-edges.html
@@ -11,12 +11,12 @@
       <h1>Tests — <code>getFocusableEdges()</code></h1>
       <div id="light-dom-two-els">
         <h2>Node with two focusable Light DOM element children</h2>
-        <button id="start">Start</button>
-        <a href="#">End</a>
+        <button id="first">Start</button>
+        <a href="#" id="last">End</a>
       </div>
       <div id="light-dom-one-el">
         <h2>Node with one focusable Light DOM element child</h2>
-        <button id="start">Start</button>
+        <button id="solo">Start</button>
       </div>
       <div id="light-dom-no-els">
         <h2>Node with no focusable element children</h2>

--- a/cypress/fixtures/get-focusable-edges.html
+++ b/cypress/fixtures/get-focusable-edges.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Tests — Base</title>
+  <link rel="stylesheet" href="../styles.css" />
+</head>
+
+<body>
+  <main>
+    <h1>Tests — <code>getFocusableEdges()</code></h1>
+    <div id="light-dom-two-els">
+      <h2>Node with two focusable Light DOM element children</h2>
+      <button id="start">Start</button>
+      <a href="#">End</a>
+    </div>
+    <div id="light-dom-one-el">
+      <h2>Node with one focusable Light DOM element child</h2>
+      <button id="start">Start</button>
+    </div>
+    <div id="light-dom-no-els">
+      <h2>Node with no focusable element children</h2>
+    <script>
+      window.customElements.define(
+        'fancy-button',
+        class FancyButton extends HTMLElement {
+          constructor() {
+            super()
+            this.attachShadow({
+              delegatesFocus: true,
+              mode: 'open',
+            }).innerHTML = `
+  <style>
+    *:focus-visible {outline: 2px solid #005ec2; outline-offset: 2px}
+    :host { display: inline-block; }
+    button {
+      appareance: none;
+      border: 2px solid #005ec2;
+      border-radius: 4px;
+      background-color: #007bff;
+      color: white;
+      cursor: pointer;
+      display: inline-block;
+      font-size: inherit;
+      padding: 0.25em 0.75em;
+    }
+  </style>
+  <button part="root"><slot></slot></button>
+`
+          }
+        }
+      )
+      window.customElements.define(
+        'fancy-card',
+        class MyCard extends HTMLElement {
+          constructor() {
+            super()
+            this.attachShadow({
+              mode: 'open',
+            }).innerHTML = `
+  <style>
+    :host  { contain: content; margin-block: 1em; }
+    .container {
+      background-color: aliceblue;
+      border: 1px solid skyblue;
+      border-radius: 4px;
+      display: flex;
+      flex-direction: column;
+      margin-top: 1em;
+      padding: 0.5em;
+    }
+    .container > * + * { margin-top: 1em; }
+    a { display: inline-block }
+    p { margin: 0 }
+  </style>
+  <div class="container">
+    <slot></slot>
+    <fancy-button>I'm in the card's Shadow DOM</fancy-button>
+  </div>
+`
+          }
+        }
+      )
+      window.customElements.define(
+        'fancy-div',
+        class MyCard extends HTMLElement {
+          constructor() {
+            super()
+            this.attachShadow({
+              mode: 'open',
+            }).innerHTML = `
+  <style>
+    :host { contain: content; display: inline-block; }
+  </style>
+  <div>
+    <slot></slot>
+  </div>
+`
+          }
+        }
+      )
+    </script>
+</body>
+
+</html>

--- a/cypress/fixtures/get-focusable-edges.html
+++ b/cypress/fixtures/get-focusable-edges.html
@@ -79,6 +79,15 @@
           <p>Hello, <a href="#">link</a></p>
         </fancy-card>
       </div>
+      <div id="with-details">
+        <h2>With details & summary elements</h2>
+        <details>
+          <summary>Hellaur</summary>
+          <p>What are frogs?
+            <a href="#">Science</a> may one day understand.
+          </p>
+        </details>
+      </div>
     </main>
     <script>
       window.customElements.define(

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -55,4 +55,13 @@ export default [
       },
     ],
   },
+  {
+    input: 'src/dom-utils.ts',
+    plugins: plugins,
+    output: [
+      {
+        file: 'cypress/fixtures/dom-utils.js',
+      },
+    ],
+  },
 ]

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -13,7 +13,7 @@ export function moveFocusToDialog(el: HTMLElement) {
 /**
  * Get the first and last focusable elements in a given tree.
  */
-function getFocusableEdges(el: HTMLElement) {
+export function getFocusableEdges(el: HTMLElement) {
   // Check for a focusable element within the subtree of `el`.
   const first = findFocusableElement(el, true)
 


### PR DESCRIPTION
## Summary

This PR adds a suite of tests for the behavior of `getFocusableEdges()` to ensure that we cover a wide-but-reasonable range of possible DOM structures.

Note: 3 of the tests describe expected browser behaviors we do not yet account for. Those behaviors can be fixed in a follow-up PR.