### PR TITLE
[Version 8] Clone dialog element in-place on destroy

### DIFF
--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -45,6 +45,10 @@ export default class A11yDialog {
     // Remove the click event delegates for our openers and closers
     document.removeEventListener('click', this.handleTriggerClicks, true)
 
+    // Clone and replace the dialog element to prevent memory leaks caused by
+    // event listeners that the author might not have cleaned up.
+    this.$el.replaceWith(this.$el.cloneNode(true))
+
     // Dispatch a `destroy` event
     this.fire('destroy')
 


### PR DESCRIPTION
## Summary
As it says on the tin. This is a quick way to free up any event listeners the author may have bound with `.on()`, without us having to track and manually unbind all of those listeners.