### PR TITLE
[Version 8] Fix focus handling for some HTML cases

### DIFF
--- a/cypress/e2e/focusTrap.cy.js
+++ b/cypress/e2e/focusTrap.cy.js
@@ -245,7 +245,6 @@ describe('Focus trap', () => {
    * has a negative tabindex. This applies to both slotted Light DOM Shadow DOM
    * children
    */
-  // TODO: This test is currently failing. We do not match this browser behavior yet.
   it('should ignore shadow hosts with a negative tabindex', () => {
     cy.runExample({
       html: /* html */ `
@@ -285,8 +284,6 @@ describe('Focus trap', () => {
    * focusable-selectors and may still have dimensions, so we need a special
    * case to ignore them.
    */
-  // TODO: This test is currently failing. We do not match this browser
-  // behavior yet.
   it('should ignore non-<summary> elements in a closed <details>', () => {
     cy.runExample({
       html: stripIndent(/* html */ `

--- a/cypress/e2e/focusTrap.cy.js
+++ b/cypress/e2e/focusTrap.cy.js
@@ -214,15 +214,19 @@ describe('Focus trap', () => {
 
         // Assert that we have a shadow host that delegates focus to its subtree
         cy.get('@shadowHost')
+          .should('have.prop', 'localName', 'fancy-button')
           .shadow()
           .should('have.prop', 'delegatesFocus', true)
 
         // Assert that the shadowHost is *not* what our library returns
         cy.get('@first')
-          .should('not.deep.equal', '@shadowHost')
-          // and that it is a button within a shadowRoot
+          // First check that it is a button within a shadowRoot
           .and('have.prop', 'localName', 'button')
           .and('be.withinShadowRoot')
+          // then check that it is not the same as the shadow host
+          .then(first => {
+            cy.get('@shadowHost').its(0).should('not.deep.equal', first.get(0))
+          })
       }),
     })
   })

--- a/cypress/e2e/focusTrap.cy.js
+++ b/cypress/e2e/focusTrap.cy.js
@@ -293,8 +293,7 @@ describe('Focus trap', () => {
         // Assert that the <summary> is the only focusable element our library
         // finds
         cy.get('@first')
-          .should('be.element')
-          .and('have.prop', 'localName', 'summary')
+          .should('be.element', 'summary')
           .then(first => {
             cy.get('@last').should('deep.equal', first.get(0))
           })

--- a/cypress/e2e/focusTrap.cy.js
+++ b/cypress/e2e/focusTrap.cy.js
@@ -191,20 +191,6 @@ describe('Focus trap', () => {
     })
   })
 
-  /**
-   * A shadow host that delegates focus will never directly receive focus,
-   * even when the host itself is focusable. Consider our <fancy-button> custom
-   * element, which delegates focus. If we were to apply a tabindex to it, it
-   * would look like this:
-   *
-   * <fancy-button tabindex="0">
-   *  #shadow-root
-   *  <button><slot></slot></button>
-   * </fancy-button>
-   *
-   * The browser acts as as if there is only one focusable element – the shadow
-   * button. Our library should behave the same way.
-   */
   it('should ignore focusable shadow hosts if they delegate focus to their shadow subtree', () => {
     cy.runExample({
       html: stripIndent(/* html */ `
@@ -240,11 +226,7 @@ describe('Focus trap', () => {
       }),
     })
   })
-  /**
-   * The browser will never send focus into a Shadow DOM if the host element
-   * has a negative tabindex. This applies to both slotted Light DOM Shadow DOM
-   * children
-   */
+
   it('should ignore shadow hosts with a negative tabindex', () => {
     cy.runExample({
       html: /* html */ `
@@ -278,12 +260,6 @@ describe('Focus trap', () => {
     })
   })
 
-  /**
-   * Browsers hide all non-<summary> descendants of closed <details> elements
-   * from user interaction, but those non-<summary> elements may still match our
-   * focusable-selectors and may still have dimensions, so we need a special
-   * case to ignore them.
-   */
   it('should ignore non-<summary> elements in a closed <details>', () => {
     cy.runExample({
       html: stripIndent(/* html */ `

--- a/cypress/e2e/focusTrap.cy.js
+++ b/cypress/e2e/focusTrap.cy.js
@@ -247,21 +247,32 @@ describe('Focus trap', () => {
  * children
  */
 // TODO: This test is currently failing. We do not match this browser behavior yet.
-it.skip('should ignore shadow hosts with a negative tabindex', () => {
-  cy.get('#shadow-host-negative-tabindex').then(container => {
-    // Get the <fancy-card> with a negative tabindex
-    const shadowHostEl = container.find('[data-cy-negative-tabindex]')[0]
-    // Get the first and last focusable element, according to our library
-    const [first, last] = getFocusableEdges(container[0])
+it('should ignore shadow hosts with a negative tabindex', () => {
+  cy.runExample({
+    html: stripIndent(/* html */ ` <div id="shadow-host-negative-tabindex">
+    <fancy-card tabindex="-1" data-cy-negative-tabindex>
+      <h3>AAAA</h3>
+      <p>Hello, <a href="#">link</a></p>
+    </fancy-card>
+  </div>`),
+    test: serialize(() => {
+      // Get the first and last focusable element, according to our library
+      cy.get('#shadow-host-negative-tabindex')
+        .as('container')
+        .aliasFocusableEdges({ skipAliases: true })
 
-    // Assert that the shadow host has a negative tabindex
-    expect(shadowHostEl).to.have.attr('tabindex', '-1')
-    // Asseert that the shadow DOM contains a <fancy-button>
-    expect(shadowHostEl.shadowRoot?.querySelector('fancy-button')).to.not.be
-      .null
-    // Assert that our library finds no focusable elements in this container
-    expect(first).to.be.null
-    expect(last).to.be.null
+      // Get the shadow host with a negative tabindex
+      cy.get('@container').find('[data-cy-negative-tabindex]').as('shadowHost')
+
+      // Assert that the shadow host has a negative tabindex
+      cy.get('@shadowHost').should('have.attr', 'tabindex', '-1')
+      // Asseert that the shadow DOM contains a <fancy-button>
+      cy.get('@shadowHost').shadow().find('fancy-button').should('exist')
+
+      // Assert that our library finds no focusable elements in this container
+      cy.get('@edges').its('0').should('be.null')
+      cy.get('@edges').its('1').should('be.null')
+    }),
   })
 })
 

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -21,7 +21,14 @@ Cypress.Commands.add(
 )
 
 chai.use(_chai => {
-  _chai.Assertion.addMethod('element', function isElement() {
+  _chai.Assertion.addMethod('element', function isElement(localName) {
+    if (localName) {
+      this.assert(
+        this._obj.localName === localName,
+        `expected #{this} to be an element with localName "${localName}"`,
+        `expected #{this} not to be an element with localName "${localName}"`
+      )
+    }
     this.assert(
       Cypress.dom.isElement(this._obj),
       `expected #{this} to be an element`,

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -99,14 +99,28 @@ function getNextSiblingEl(el: HTMLElement, forward: boolean) {
 }
 
 /**
+ * Determine if an element is hidden from the user.
+ */
+const isHidden = (el: HTMLElement) => {
+  // If this is a descendant of a closed <details> and NOT a <summary>,
+  // it's hidden.
+  if (
+    el.matches('details:not([open]) *') &&
+    !el.matches('details>summary:first-of-type')
+  )
+    return true
+
+  // If this element has no painted dimensions, it's hidden.
+  return !(el.offsetWidth || el.offsetHeight || el.getClientRects().length)
+}
+
+/**
  * Determine if an element is focusable and has user-visible painted dimensions.
  */
-export function isFocusable(el: HTMLElement) {
+const isFocusable = (el: HTMLElement) => {
+  // A shadow host that delegates focus is not focusable.
   if (el.shadowRoot?.delegatesFocus) return false
-  return (
-    el.matches(focusableSelectors.join(',')) &&
-    !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length)
-  )
+  return el.matches(focusableSelectors.join(',')) && !isHidden(el)
 }
 
 /**

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -102,8 +102,12 @@ function getNextSiblingEl(el: HTMLElement, forward: boolean) {
  * Determine if an element is hidden from the user.
  */
 const isHidden = (el: HTMLElement) => {
-  // If this is a descendant of a closed <details> and NOT a <summary>,
-  // it's hidden.
+  /**
+   * Browsers hide all non-<summary> descendants of closed <details> elements
+   * from user interaction, but those non-<summary> elements may still match our
+   * focusable-selectors and may still have dimensions, so we need a special
+   * case to ignore them.
+   */
   if (
     el.matches('details:not([open]) *') &&
     !el.matches('details>summary:first-of-type')
@@ -118,16 +122,27 @@ const isHidden = (el: HTMLElement) => {
  * Determine if an element is focusable and has user-visible painted dimensions.
  */
 const isFocusable = (el: HTMLElement) => {
-  // A shadow host that delegates focus is not focusable.
+  /**
+   * A shadow host that delegates focus will never directly receive focus,
+   * even with `tabindex=0`. Consider our <fancy-button> custom element, which
+   * delegates focus to its shadow button:
+   *
+   * <fancy-button tabindex="0">
+   *  #shadow-root
+   *  <button><slot></slot></button>
+   * </fancy-button>
+   *
+   * The browser acts as as if there is only one focusable element – the shadow
+   * button. Our library should behave the same way.
+   */
   if (el.shadowRoot?.delegatesFocus) return false
+
   return el.matches(focusableSelectors.join(',')) && !isHidden(el)
 }
 
 /**
  * Determine if an element can have focusable children. Useful for bailing out
- * early when walking the DOM tree. Note: while this check has some overlap with
- * `isFocusable`, its goal is to bail on an entire subtree, so it has to happen
- * at a different time.
+ * early when walking the DOM tree.
  * @example
  * This div is inert, so none of its children can be focused, even though they
  * meet our criteria for what is focusable. Once we check the div, we can skip
@@ -140,12 +155,18 @@ const isFocusable = (el: HTMLElement) => {
  * ```
  */
 function canHaveFocusableChildren(el: HTMLElement) {
-  // If an element is a shadow host with a negative tabindex, it cannot have
-  // focusable children.
+  /**
+   * The browser will never send focus into a Shadow DOM if the host element
+   * has a negative tabindex. This applies to both slotted Light DOM Shadow DOM
+   * children
+   */
   if (el.shadowRoot && el.getAttribute('tabindex') === '-1') return false
-  // Elemments matching this selector are either hidden entirely from the user,
-  // or are visible but unavailable for interaction. Their descentants can never
-  // receive focus.
+
+  /**
+   * Elemments matching this selector are either hidden entirely from the user,
+   * or are visible but unavailable for interaction. Their descentants can never
+   * receive focus.
+   */
   return !el.matches(':disabled,[hidden],[inert]')
 }
 

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -102,12 +102,10 @@ function getNextSiblingEl(el: HTMLElement, forward: boolean) {
  * Determine if an element is hidden from the user.
  */
 const isHidden = (el: HTMLElement) => {
-  /**
-   * Browsers hide all non-<summary> descendants of closed <details> elements
-   * from user interaction, but those non-<summary> elements may still match our
-   * focusable-selectors and may still have dimensions, so we need a special
-   * case to ignore them.
-   */
+  // Browsers hide all non-<summary> descendants of closed <details> elements
+  // from user interaction, but those non-<summary> elements may still match our
+  // focusable-selectors and may still have dimensions, so we need a special
+  // case to ignore them.
   if (
     el.matches('details:not([open]) *') &&
     !el.matches('details>summary:first-of-type')
@@ -122,19 +120,17 @@ const isHidden = (el: HTMLElement) => {
  * Determine if an element is focusable and has user-visible painted dimensions.
  */
 const isFocusable = (el: HTMLElement) => {
-  /**
-   * A shadow host that delegates focus will never directly receive focus,
-   * even with `tabindex=0`. Consider our <fancy-button> custom element, which
-   * delegates focus to its shadow button:
-   *
-   * <fancy-button tabindex="0">
-   *  #shadow-root
-   *  <button><slot></slot></button>
-   * </fancy-button>
-   *
-   * The browser acts as as if there is only one focusable element – the shadow
-   * button. Our library should behave the same way.
-   */
+  // A shadow host that delegates focus will never directly receive focus,
+  // even with `tabindex=0`. Consider our <fancy-button> custom element, which
+  // delegates focus to its shadow button:
+  //
+  // <fancy-button tabindex="0">
+  //  #shadow-root
+  //  <button><slot></slot></button>
+  // </fancy-button>
+  //
+  // The browser acts as as if there is only one focusable element – the shadow
+  // button. Our library should behave the same way.
   if (el.shadowRoot?.delegatesFocus) return false
 
   return el.matches(focusableSelectors.join(',')) && !isHidden(el)
@@ -155,18 +151,14 @@ const isFocusable = (el: HTMLElement) => {
  * ```
  */
 function canHaveFocusableChildren(el: HTMLElement) {
-  /**
-   * The browser will never send focus into a Shadow DOM if the host element
-   * has a negative tabindex. This applies to both slotted Light DOM Shadow DOM
-   * children
-   */
+  // The browser will never send focus into a Shadow DOM if the host element
+  // has a negative tabindex. This applies to both slotted Light DOM Shadow DOM
+  // children
   if (el.shadowRoot && el.getAttribute('tabindex') === '-1') return false
 
-  /**
-   * Elemments matching this selector are either hidden entirely from the user,
-   * or are visible but unavailable for interaction. Their descentants can never
-   * receive focus.
-   */
+  // Elemments matching this selector are either hidden entirely from the user,
+  // or are visible but unavailable for interaction. Their descentants can never
+  // receive focus.
   return !el.matches(':disabled,[hidden],[inert]')
 }
 

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -102,6 +102,7 @@ function getNextSiblingEl(el: HTMLElement, forward: boolean) {
  * Determine if an element is focusable and has user-visible painted dimensions.
  */
 export function isFocusable(el: HTMLElement) {
+  if (el.shadowRoot?.delegatesFocus) return false
   return (
     el.matches(focusableSelectors.join(',')) &&
     !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length)

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -126,6 +126,9 @@ export function isFocusable(el: HTMLElement) {
  * ```
  */
 function canHaveFocusableChildren(el: HTMLElement) {
+  // If an element is a shadow host with a negative tabindex, it cannot have
+  // focusable children.
+  if (el.shadowRoot && el.getAttribute('tabindex') === '-1') return false
   // Elemments matching this selector are either hidden entirely from the user,
   // or are visible but unavailable for interaction. Their descentants can never
   // receive focus.


### PR DESCRIPTION
## Summary

This PR allows a11y-dialog to handle focus for some previously unhandled cases:
- When a `<details>` element is closed
- When a Custom Element delegates focus to its shadow children (it should never be focused; instead an element in its shadow tree will be)
- When a Custom Element explicitly has `tabindex=-1` (the browser will never send focus to it or any of its children, including both Light and Shadow DOM)

We also add some tests. These were originally written in #470 and have been redone following in our new `cypress-fiddle` pattern

I made [a quick codepen](https://codepen.io/mxmason/pen/oNMPrQM) to validate these browser behaviors