### PR TITLE
fix: remove event handlers before hiding dialog

### DIFF
--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -93,14 +93,14 @@ export default class A11yDialog {
     // If the dialog is already closed, abort
     if (!this.shown) return this
 
-    this.shown = false
-    this.$el.setAttribute('aria-hidden', 'true')
-    this.previouslyFocused?.focus?.()
-
     // Remove the focus event listener to the body element and stop listening
     // for specific key presses
     document.body.removeEventListener('focus', this.maintainFocus, true)
     this.$el.removeEventListener('keydown', this.bindKeypress, true)
+
+    this.shown = false
+    this.$el.setAttribute('aria-hidden', 'true')
+    this.previouslyFocused?.focus?.()
 
     // Dispatch a `hide` event
     this.fire('hide', event)


### PR DESCRIPTION
**What**

This updates the `hide()` method to remove the `focus` and `keydown`
handlers *before* hiding the dialog.

**Why**

This is unlikely to be an issue for day-to-day users, but we've noticed
some test flake when converting our dialogs from Bootstrap modals to
A11y Dialog. What seems to be happening is that the test driver is
trying to click on a link outside the dialog after the dialog is hidden
but *before* the `maintainFocus` callback is removed. The driver clicks
on the link on the page, but nothing happens, as if something is
blocking the link from receiving the click.

**Notes**

We're using Capybara as our test driver and our tests are running in
Firefox. One alternative might be to add a callback on the `hide` event
and add another data attribute to assert against in our tests, but this
seemed like it might be impacting others whether they notice it or not.
