### PR TITLE
 Consider open popovers when pressing ESC 

### DIFF
--- a/cypress/e2e/state.cy.js
+++ b/cypress/e2e/state.cy.js
@@ -34,6 +34,17 @@ describe('State', { testIsolation: false }, () => {
     cy.get('.dialog').then(shouldBeHidden)
   })
 
+  it('should not close when pressing ESC if it contains an open popover', () => {
+    cy.get('[data-a11y-dialog-show="my-dialog"]').click()
+    cy.get('[popovertarget]').click()
+    cy.get('[popover]').should('be.visible')
+    cy.realPress('Escape')
+    cy.get('[popover]').should('not.be.visible')
+    cy.get('.dialog').then(shouldBeVisible)
+    cy.realPress('Escape')
+    cy.get('.dialog').then(shouldBeHidden)
+  })
+
   it('should close when clicking the backdrop', () => {
     cy.get('[data-a11y-dialog-show="my-dialog"]').click()
     cy.get('.dialog-overlay').click({ force: true })

--- a/cypress/fixtures/base.html
+++ b/cypress/fixtures/base.html
@@ -22,7 +22,13 @@
       <h1 id="my-dialog-title">Dialog title</h1>
 
       <form>
-        <label for="email">Email (required)</label>
+        <label for="email">Email (required)
+          <button type="button" popovertarget="email-tip" aria-describedby="email-tip">!</button>
+        </label>
+        <p id="email-tip" popover>
+          Make sure your email address is correct as we’ll send you a confirmation email that you’ll need to read to
+          activate your account.
+        </p>
         <input type="email" name="EMAIL" id="email" placeholder="john.doe@gmail.com" required>
         <button type="submit" name="button">Sign up</button>
       </form>

--- a/cypress/fixtures/styles.css
+++ b/cypress/fixtures/styles.css
@@ -56,7 +56,9 @@
 }
 
 .dialog-content {
-  animation: fade-in 400ms 200ms both, slide-up 400ms 200ms both;
+  animation:
+    fade-in 400ms 200ms both,
+    slide-up 400ms 200ms both;
 }
 
 .dialog-content {
@@ -121,13 +123,16 @@ body {
   align-items: stretch;
   display: flex;
   flex-direction: column;
-  font: 125% / 1.5 -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
+  font:
+    125% / 1.5 -apple-system,
+    BlinkMacSystemFont,
+    Segoe UI,
+    Helvetica,
+    Arial,
     sans-serif;
   gap: 1em;
   padding: 2em 0;
 }
-
-
 
 h1 {
   font-size: 1.6em;
@@ -194,11 +199,11 @@ fancy-div:focus {
 main {
   align-items: flex-start;
   display: flex;
-	flex-basis: 100%;
+  flex-basis: 100%;
   flex-direction: column;
   gap: 0.5em;
-	margin: 0;
-	padding: 0 1em;
+  margin: 0;
+  padding: 0 1em;
 }
 
 footer {
@@ -212,6 +217,7 @@ footer {
 
 form {
   margin-top: 2em;
+  position: relative;
 }
 
 @media screen and (min-width: 700px) {
@@ -258,4 +264,38 @@ form button {
 form button:hover,
 form button:active {
   background-color: #66bb6a;
+}
+
+[popovertarget] {
+  border: 1px solid #00f;
+  background-color: #00f;
+  font-weight: bold;
+  font-size: 125%;
+  line-height: 0;
+  color: #fff;
+  border-radius: 50%;
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  margin: 0;
+  padding: 0;
+}
+
+[popovertarget]:focus,
+[popovertarget]:hover {
+  color: #00f;
+  background-color: #ff0;
+}
+
+[popover] {
+  background-color: #ff9;
+  padding: 0.5em 1em;
+  max-width: 12.5em;
+  font-weight: normal;
+  position: absolute;
+  left: 2em;
+  top: 13.5em;
+  border: 1px solid #cc0;
+  border-radius: 0.25em;
+  box-shadow: 0 0 0.5em #333;
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "rollup -c",
     "serve": "npx serve cypress/fixtures -p 5000",
-    "test": "cypress run",
+    "test": "cypress run --browser chrome",
     "size": "./size.sh",
     "prepare": "husky install"
   },

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -193,11 +193,13 @@ export default class A11yDialog {
     }
 
     // If the dialog is shown and the ESC key is pressed, prevent any further
-    // effects from the ESC key and hide the dialog, unless its role is
-    // `alertdialog`, which should be modal
+    // effects from the ESC key and hide the dialog, unless:
+    // - its role is `alertdialog`, which means it should be modal
+    // - or it contains an open popover, in which case ESC should close it
     if (
       event.key === 'Escape' &&
-      this.$el.getAttribute('role') !== 'alertdialog'
+      this.$el.getAttribute('role') !== 'alertdialog' &&
+      !this.$el.querySelector('[popover]:not([popover="manual"]):popover-open')
     ) {
       event.preventDefault()
       this.hide(event)


### PR DESCRIPTION
As outlined in [Brief Note on Popovers with Dialogs](https://adrianroselli.com/2023/05/brief-note-on-popovers-with-dialogs.html) by @aardrian, a pitfall of using the new [Popover API](https://developer.chrome.com/blog/introducing-popover-api/) alongside non-native dialogs is that attempting to close a popover with <kbd>ESC</kbd> or clicking outside of it may end up closing the dialog itself.

This pull-request will ensure that pressing <kbd>ESC</kbd> when the dialog contains an open non-manual does **not** close the dialog. It also adds a test to make sure it works fine and we don’t break that important behavior.

What this pull-request does **not** cover is avoiding closing the dialog when clicking the backdrop while a non-manual popover is open inside it. This is more challenging to solve unfortunately.