### PR TITLE
Respect ignore-focus attribute when shown via focus event

### DIFF
--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -3,6 +3,10 @@ import { getActiveElement, moveFocusToDialog, trapTabKey } from './dom-utils'
 export type A11yDialogEvent = 'show' | 'hide' | 'destroy'
 export type A11yDialogInstance = InstanceType<typeof A11yDialog>
 
+function isFocusEvent(event?: Event): event is FocusEvent {
+  return event?.type === 'focus'
+}
+
 export default class A11yDialog {
   private $el: HTMLElement
   private id: string
@@ -81,7 +85,11 @@ export default class A11yDialog {
     }
 
     // Set the focus to the dialog element
-    moveFocusToDialog(this.$el)
+    if (isFocusEvent(event)) {
+      this.maintainFocus(event)
+    } else {
+      moveFocusToDialog(this.$el)
+    }
 
     // Bind a focus event listener to the body element to make sure the focus
     // stays trapped inside the dialog while open, and start listening for some


### PR DESCRIPTION
Re-use the `A11yDialog.maintainFocus()` method to set focus when the dialog is shown so that the `data-a11y-dialog-ignore-focus-trap` attribute on the event target is respected.

See https://github.com/KittyGiraudel/a11y-dialog/issues/564#issuecomment-1730377629 for more context.