### PR TITLE
add exports field to package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ cypress/screenshots
 out
 dist/
 cypress/fixtures/*.js
+cypress/fixtures/*.cjs
 !cypress/fixtures/shadow-dom-fixture.js
 

--- a/cypress/fixtures/alert-dialog.html
+++ b/cypress/fixtures/alert-dialog.html
@@ -29,7 +29,7 @@
     </div>
   </div>
 
-  <script src="./a11y-dialog.js"></script>
+  <script src="./a11y-dialog.cjs"></script>
 </body>
 
 </html>

--- a/cypress/fixtures/base.html
+++ b/cypress/fixtures/base.html
@@ -41,7 +41,7 @@
     <button type="button" id="focus-me">Focus me</button>
   </div>
 
-  <script src="./a11y-dialog.js"></script>
+  <script src="./a11y-dialog.cjs"></script>
   <script>
     document.querySelector('#move-focus-outside').addEventListener('click', () => {
       document.querySelector('#focus-me').focus()

--- a/cypress/fixtures/focus.html
+++ b/cypress/fixtures/focus.html
@@ -75,7 +75,7 @@
     <button type="button" id="focus-me">Focus me</button>
   </div>
 
-  <script src="./a11y-dialog.js"></script>
+  <script src="./a11y-dialog.cjs"></script>
   <script src="./shadow-dom-fixture.js"></script>
   <script>
     document.querySelector('#move-focus-outside').addEventListener('click', () => {

--- a/cypress/fixtures/instance.html
+++ b/cypress/fixtures/instance.html
@@ -31,7 +31,7 @@
     </div>
   </div>
 
-  <script src="./a11y-dialog.js"></script>
+  <script src="./a11y-dialog.cjs"></script>
 </body>
 
 </html>

--- a/cypress/fixtures/nested-dialogs.html
+++ b/cypress/fixtures/nested-dialogs.html
@@ -42,7 +42,7 @@
     </div>
   </div>
 
-  <script src="./a11y-dialog.js"></script>
+  <script src="./a11y-dialog.cjs"></script>
 </body>
 
 </html>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,21 @@
   "main": "dist/a11y-dialog.js",
   "module": "dist/a11y-dialog.esm.js",
   "types": "dist/a11y-dialog.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/a11y-dialog.esm.js",
+      "require": "./dist/a11y-dialog.js",
+      "types": "./dist/a11y-dialog.d.ts"
+    },
+    "dist/*.esm.js": "./dist/*.esm.js",
+    "dist/*.js": "./dist/*.js",
+    "dist/*": {
+      "import": "./dist/*.esm.js",
+      "require": "./dist/*.js",
+      "types": "./dist/*.d.ts"
+    },
+    "package.json": "./package.json"
+  },
   "keywords": [
     "modal",
     "dialog",

--- a/package.json
+++ b/package.json
@@ -9,16 +9,15 @@
   "module": "dist/a11y-dialog.esm.js",
   "types": "dist/a11y-dialog.d.ts",
   "exports": {
-    ".": {
-      "import": "./dist/a11y-dialog.esm.js",
-      "require": "./dist/a11y-dialog.js",
-      "types": "./dist/a11y-dialog.d.ts"
-    },
+    "import": "./dist/a11y-dialog.esm.js",
+    "require": "./dist/a11y-dialog.cjs",
+    "types": "./dist/a11y-dialog.d.ts",
     "dist/*.esm.js": "./dist/*.esm.js",
-    "dist/*.js": "./dist/*.js",
+    "dist/*.cjs": "./dist/*.cjs",
+    "dist/*.js": "./dist/*.cjs",
     "dist/*": {
       "import": "./dist/*.esm.js",
-      "require": "./dist/*.js",
+      "require": "./dist/*.cjs",
       "types": "./dist/*.d.ts"
     },
     "package.json": "./package.json"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,16 +27,16 @@ export default [
     output: [
       {
         ...umdCfg,
-        file: 'dist/a11y-dialog.js',
+        file: 'dist/a11y-dialog.cjs',
       },
       {
         ...umdCfg,
-        file: 'dist/a11y-dialog.min.js',
+        file: 'dist/a11y-dialog.min.cjs',
         plugins: [minify],
       },
       {
         ...umdCfg,
-        file: 'cypress/fixtures/a11y-dialog.js',
+        file: 'cypress/fixtures/a11y-dialog.cjs',
       },
     ],
   },


### PR DESCRIPTION
fixes https://github.com/KittyGiraudel/a11y-dialog/issues/646

Left some inline comments on what each part is for. Mostly I'm being defensive, so that if any of these import patterns are already in use, they'll still work and this can be a minor version bump.

I'd recommend at some point locking this down to just the `.` and the `package.json` entries and making that a major version bump.