### PR TITLE
Add custom event in escape handler

### DIFF
--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -213,14 +213,25 @@ export default class A11yDialog {
     // If the dialog is shown and the ESC key is pressed, prevent any further
     // effects from the ESC key and hide the dialog, unless:
     // - its role is `alertdialog`, which means it should be modal
-    // - or it contains an open popover, in which case ESC should close it
+    // - it contains an open popover, in which case ESC should close it
+    // - or the custom event dialog:escape is cancelled
     if (
       event.key === 'Escape' &&
       this.$el.getAttribute('role') !== 'alertdialog' &&
       !hasOpenPopover
     ) {
-      event.preventDefault()
-      this.hide(event)
+      const escapeEvent = new CustomEvent('dialog:escape', {
+        bubbles: true,
+        cancelable: true,
+        detail: { originalEvent: event },
+      })
+
+      this.$el.dispatchEvent(escapeEvent)
+
+      if (!escapeEvent.defaultPrevented) {
+        event.preventDefault()
+        this.hide(event)
+      }
     }
 
     // If the dialog is shown and the TAB key is pressed, make sure the focus

--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -1,6 +1,6 @@
 import { getActiveElement, moveFocusToDialog, trapTabKey } from './dom-utils'
 
-export type A11yDialogEvent = 'show' | 'hide' | 'destroy'
+export type A11yDialogEvent = 'show' | 'hide' | 'destroy' | 'escape'
 export type A11yDialogInstance = InstanceType<typeof A11yDialog>
 
 export default class A11yDialog {
@@ -156,12 +156,15 @@ export default class A11yDialog {
    * code
    */
   private fire(type: A11yDialogEvent, event?: Event) {
-    this.$el.dispatchEvent(
-      new CustomEvent(type, {
-        detail: event,
-        cancelable: true,
-      })
-    )
+    const customEvent = new CustomEvent(type, {
+      detail: event,
+      bubbles: true,
+      cancelable: true,
+    })
+
+    this.$el.dispatchEvent(customEvent)
+
+    return customEvent
   }
 
   /**
@@ -220,13 +223,7 @@ export default class A11yDialog {
       this.$el.getAttribute('role') !== 'alertdialog' &&
       !hasOpenPopover
     ) {
-      const escapeEvent = new CustomEvent('dialog:escape', {
-        bubbles: true,
-        cancelable: true,
-        detail: { originalEvent: event },
-      })
-
-      this.$el.dispatchEvent(escapeEvent)
+      const escapeEvent = this.fire('escape', event)
 
       if (!escapeEvent.defaultPrevented) {
         event.preventDefault()


### PR DESCRIPTION
Hello! ;) 

This PR is for #694 It adds a [custom event](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent) to the Escape key handler. 

The name of this custom event is hardcoded at this stage and is called `dialog:escape`

**Use Case:** Dialog has a child component that needs the escape key for  its own functionality. For example, an ARIA Combobox with an expanded Listbox where escape should collapse that expanded Listbox instead of closing the dialog. 

If a11y-dialog users wanted to get in front of the default Escape key functionality they would listen for this new custom event  `dialog:escape` and simply use `preventDefault();` in that component's JavaScript.

Example use: ARIA APG Select Combobox init
``` javascript
Select.prototype.init = function () {
    /* ... */
    document.addEventListener('dialog:escape', (event) => {
        if (this.open) { // Check if the dropdown is open
            this.updateMenuState(false); // Close the dropdown
            event.preventDefault(); // Prevent default behavior stops escape from working in a11y-dialog
        }
    });
}
```
I look forward to seeing what you cook up for documentation and tests and hope others enjoy this addition. Thanks for supporting a11y-dialog too @KittyGiraudel 